### PR TITLE
docs(claude): document the intentional gosec baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,7 @@ See `docs/impl/0002-mvp-cli-gap-closure.md` for the full history and rationale.
 - Tests use `testify` for assertions; test helpers must call `t.Helper()`
 - Mocks generated with `mockery`
 - `nolint` directives require both an explanation and a specific linter name
+- **gosec baseline:** 5 inline `//nolint:gosec` directives intentionally annotate correct-by-design CLI behaviour (file writes to user-chosen output dirs, `git` against user registry dirs, hook execution from `blueprint.yaml`). They live in `internal/create/create.go`, `internal/sync/overwrite.go`, `internal/hooks/hooks.go`, `internal/registrycmd/registrycmd.go`, `internal/registrycmd/update.go`. Don't remove without a real fix — gosec reports them as G703/G204.
 
 ## CI/CD
 


### PR DESCRIPTION
## Summary

One-line addition to `CLAUDE.md` calling out the five intentional `//nolint:gosec` annotations introduced in IMPL-0004 (PR #20). Surfaces them in the Code Style section so future work on `internal/create`, `internal/sync`, `internal/hooks`, and `internal/registrycmd` doesn't strip the directives without realising they're load-bearing for `make ci` lint.

All five annotate correct-by-design CLI behaviour:

- File writes into user-chosen output / project directories.
- `git init` / `git rev-parse` against the user's own registry directory.
- `sh -c <hook>` execution of blueprint-authored `post_create` hooks.

## Test plan

- [x] `make lint` green locally.
- [ ] Reviewer agrees the note is correctly scoped (one line, no false promises).

🤖 Generated with [Claude Code](https://claude.com/claude-code)