### PR TITLE
docs: post-cutover cleanup of pre-HCL2 references

### DIFF
--- a/docs/design/0002-registry-layout-and-defaults-inheritance.md
+++ b/docs/design/0002-registry-layout-and-defaults-inheritance.md
@@ -4,6 +4,7 @@ title: "Registry Layout and Defaults Inheritance"
 status: Implemented
 author: Donald Gifford
 created: 2026-05-07
+updated: 2026-05-11
 ---
 <!-- markdownlint-disable-file MD025 MD041 -->
 
@@ -12,6 +13,11 @@ created: 2026-05-07
 **Status:** Implemented
 **Author:** Donald Gifford
 **Date:** 2026-05-07
+**Last revised:** 2026-05-11 — bumped `apiVersion` examples to `v2`
+following the HCL2 cutover (see
+[ADR-0001](../adr/0001-use-hcl2-as-the-template-engine.md),
+[DESIGN-0003](0003-migrate-template-engine-to-hcl2.md), and the
+[migration guide](../MIGRATION.md)).
 
 <!--toc:start-->
 - [Overview](#overview)
@@ -103,7 +109,7 @@ my-registry/
 ### `registry.yaml` Schema
 
 ```yaml
-apiVersion: v1
+apiVersion: v2
 name: my-registry
 description: Company blueprint registry
 blueprints:
@@ -254,7 +260,10 @@ definitions live in `internal/config/registry.go` (`Registry`,
 
 ## Migration / Rollout Plan
 
-Schema versioned via `apiVersion: v1`. Breaking changes bump to `v2`.
+Schema versioned via `apiVersion`. Current accepted version is **v2**
+(post-HCL2 cutover). Existing v1 registries must be migrated using
+`forge migrate templates --path <registry-root>` — see
+[docs/MIGRATION.md](../MIGRATION.md).
 
 ## Hosting
 

--- a/docs/release-notes/v0.3.0-hcl2-cutover.md
+++ b/docs/release-notes/v0.3.0-hcl2-cutover.md
@@ -1,13 +1,10 @@
-# Release notes draft — HCL2 template engine cutover
+# Release notes — v0.3.0 HCL2 template engine cutover
 
-**Status:** Draft, ready to paste into the GitHub release whose tag
-covers IMPL-0004 Phases A–C.
-**Semver:** minor bump (use the `minor` PR label). The change is
-breaking in spirit but ships as a 0.x minor per IMPL-0004 OQ-9:
-pre-1.0 minors are the right channel for documented breaking
-changes.
-**Don't ship this release without:** at least one downstream
-registry already migrated (see "Before you cut" below).
+**Status:** Shipped as forge v0.3.0 on 2026-05-11 (PR #20,
+commit `b1bdeaa`). Kept here as the canonical write-up of the
+cutover for authors who land on a v1 registry post-release.
+**Semver:** minor bump per IMPL-0004 OQ-9 — pre-1.0 minors are the
+right channel for a documented breaking change.
 
 ---
 

--- a/docs/rfc/0001-forge-project-scaffolding-cli.md
+++ b/docs/rfc/0001-forge-project-scaffolding-cli.md
@@ -13,6 +13,20 @@ created: 2026-05-07
 **Author:** Donald Gifford
 **Date:** 2026-05-07
 
+> **Implementation note (2026-05-11):** The template engine and
+> `apiVersion` references below describe forge's *original* design
+> (v1, Go `text/template`). Forge v0.3.0 cut over to HCL2
+> (`hashicorp/hcl/v2`) and now requires `apiVersion: v2`. The
+> canonical authoring contract is
+> [DESIGN-0001](../design/0001-blueprint-authoring.md) (rewritten
+> for HCL2); the engine swap is documented in
+> [ADR-0001](../adr/0001-use-hcl2-as-the-template-engine.md) and
+> [DESIGN-0003](../design/0003-migrate-template-engine-to-hcl2.md).
+> Existing v1 registries migrate via `forge migrate templates` —
+> see [docs/MIGRATION.md](../MIGRATION.md). The rest of this RFC
+> (registry layout, defaults inheritance, sync semantics, lockfile,
+> CLI surface) is unchanged.
+
 <!--toc:start-->
 - [Summary](#summary)
 - [Problem Statement](#problem-statement)
@@ -78,9 +92,10 @@ A single-binary Go CLI organised around two artifacts:
 - **Registry** — a Git repo cataloging blueprints with `registry.yaml`, plus
   layered `_defaults/` directories.
 
-The CLI handles fetching (via `hashicorp/go-getter`), template rendering (Go
-`text/template`), interactive prompting (`charmbracelet/huh`), and
-ongoing sync via three-way merge.
+The CLI handles fetching (via `hashicorp/go-getter`), template rendering
+(HCL2 — `hashicorp/hcl/v2`; original design used Go `text/template`, see
+implementation note above), interactive prompting (`charmbracelet/huh`),
+and ongoing sync via three-way merge.
 
 ## Design
 
@@ -119,7 +134,7 @@ Key packages:
 - `internal/registry/` — index, resolver, cache
 - `internal/defaults/` — layered inheritance resolver
 - `internal/getter/` — `hashicorp/go-getter` wrapper
-- `internal/template/` — Go `text/template` renderer with custom funcs
+- `internal/template/` — HCL2 renderer with custom funcs (originally Go `text/template`; cut over in v0.3.0 — see DESIGN-0003)
 - `internal/prompt/` — `charmbracelet/huh` interactive prompts
 - `internal/create/`, `internal/sync/`, `internal/check/` — orchestrators
 - `internal/lockfile/` — `.forge-lock.yaml` reader/writer
@@ -335,11 +350,19 @@ managed_files:
 
 ### Template Engine
 
-Uses Go `text/template` with a custom function map: `snakeCase`, `camelCase`,
-`pascalCase`, `kebabCase`, `upper`, `lower`, `title`, `replace`, `trimPrefix`,
-`trimSuffix`, `now`, `env`, `default`. File names ending in `.tmpl` are
-rendered and the extension is stripped; other files are copied verbatim.
-Directory/file names like `{{project_name}}/` are also rendered.
+> Cut over to HCL2 in v0.3.0. See
+> [DESIGN-0001](../design/0001-blueprint-authoring.md) for the
+> current authoring contract.
+
+Originally specified as Go `text/template`. The current engine is
+HCL2 (`hashicorp/hcl/v2`) with `${expr}` interpolation and
+`%{ if … ~}` directives. Custom function map: `snakeCase`,
+`camelCase`, `pascalCase`, `kebabCase`, `now`, `env`. Standard
+library functions from `cty/function/stdlib`: `upper`, `lower`,
+`title`, `replace`, `trimPrefix`, `trimSuffix`, `coalesce`
+(replaces v1 `default`). File names ending in `.tmpl` are rendered
+and the extension is stripped; other files are copied verbatim.
+Directory/file names like `${project_name}/` are also rendered.
 
 ### Sync Strategies
 


### PR DESCRIPTION
## Summary

Sweeps the canonical docs that still described v1 (`text/template`) as the current contract now that v0.3.0 has shipped the HCL2 cutover.

- **DESIGN-0002** (registry layout) — `registry.yaml` example bumped to `apiVersion: v2`; the *Migration / Rollout Plan* section now points at `docs/MIGRATION.md` for pre-v2 registries.
- **RFC-0001** — added a top-of-doc implementation note delegating canonical authoring contract to DESIGN-0001 and the engine swap to ADR-0001 / DESIGN-0003. Inline pointers added in the Proposed Solution, Component Architecture, and Template Engine sections. The YAML example snippets stay as v1 historical illustrations — the top note covers them.
- **Release notes** — `docs/release-notes/v0.NEXT-hcl2-cutover.md` renamed to `v0.3.0-hcl2-cutover.md`; front-matter updated to reflect that the release shipped (PR #20, commit `b1bdeaa`).

The `docs/investigation/` and `docs/impl/` files that still mention `text/template` are intentionally untouched — they are point-in-time snapshots of the pre-cutover state and rewriting them would destroy the design history.

## Test plan

- [x] `grep -rn "text/template\|apiVersion: v1" docs/design/0001 docs/design/0002 README.md CLAUDE.md` returns only intentional references (migration command help, historical context notes in DESIGN-0001).
- [ ] Reviewer agrees the RFC implementation-note delegation pattern is clearer than rewriting the original spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)