### PR TITLE
Document the $${...} HCL2 escape for downstream tools

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -156,6 +156,40 @@ v2:
 direct HCL equivalent. Inline the helper, or split it into a
 separate file and reference it from blueprint hooks.
 
+#### Literal `${...}` for downstream tools (goreleaser, shell, etc.)
+
+A few downstream consumers use `${name}` as their own variable
+syntax — goreleaser, GitHub Actions expressions, shell parameter
+expansion. v1 forge ignored these (only `{{ }}` was the
+substitution syntax). Under v2, HCL2 treats every `${...}` as
+substitution, so unescaped occurrences fail strict-vars
+validation:
+
+```text
+Error: rendering template ".goreleaser.yml.tmpl":
+  Unknown variable; There is no variable named "signature".
+```
+
+The migration tool does not rewrite these because the choice
+between *"this is a forge variable I forgot to declare"* and
+*"this is a downstream variable that should be a literal"* is
+domain-specific. The fix is to escape with `$$`:
+
+```text
+v1 (no escape needed — forge ignored ${} ):
+  - "${signature}"
+  - "${artifact}"
+
+v2 (escape so HCL2 emits a literal `${...}` ):
+  - "$${signature}"
+  - "$${artifact}"
+```
+
+Same rule applies to GitHub Actions templates (`$${{ secrets.X }}`)
+and shell scripts with parameter expansion. Audit any `.tmpl`
+file that mixes forge variables with downstream `${...}` syntax
+after running `forge migrate templates`.
+
 #### Three-or-more-arg pipes
 
 ```text

--- a/docs/design/0001-blueprint-authoring.md
+++ b/docs/design/0001-blueprint-authoring.md
@@ -240,6 +240,31 @@ the renderer untouched. See
 [ADR-0001](../adr/0001-use-hcl2-as-the-template-engine.md) for the
 full rationale.
 
+#### Emitting literal `${...}` for downstream tools
+
+A few downstreams (goreleaser, GitHub Actions expression syntax,
+shell parameter expansion) do use `${name}`. Inside a `.tmpl`
+file, escape these as `$${name}` — HCL2 collapses `$$` to a
+literal `$` on render, so the output contains the bare `${name}`
+that the downstream consumer expects. Example from a goreleaser
+config that needs forge variables *and* goreleaser variables in
+the same file:
+
+```text
+release:
+  github:
+    owner: ${project_owner}      # forge variable — interpolated
+    name:  ${project_name}       # forge variable — interpolated
+signs:
+  - args:
+      - "--output"
+      - "$${signature}"          # goreleaser variable — literal ${signature}
+      - "$${artifact}"           # goreleaser variable — literal ${artifact}
+```
+
+Forge's strict-vars renderer will fail loudly if you forget the
+escape: `Unknown variable; There is no variable named "signature"`.
+
 ### Conditions
 
 Conditions allow excluding files based on variable values:


### PR DESCRIPTION
## Summary

Surfaced by the forge-registry v0.4.0 migration (PR #7 over there): blueprints that mix forge variables with downstream `\${...}` syntax (goreleaser, GitHub Actions, shell) fail strict-vars validation because HCL2 treats every `\${...}` as substitution.

The fix is to escape with `\$\$` — HCL2 collapses `\$\$` to a literal `\$` on render. This was a real-world authoring trap; documenting it in both the design contract and the migration guide so future blueprint authors don't hit the same wall.

- **DESIGN-0001** "Why HCL2" gains a sibling section "Emitting literal `\${...}` for downstream tools" with a goreleaser-shaped example.
- **MIGRATION.md** manual-fixes section calls out goreleaser, GitHub Actions expressions, and shell parameter expansion as the three common cases.

No code changes; docs only.

## Test plan

- [x] `make lint` (no-op for docs, but verifying nothing's broken).
- [x] Diff review — examples match the pattern that fixed `forge-registry/go/_defaults/.goreleaser.yml.tmpl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)