### PR TITLE
fix(migrate templates): walk blueprint.hcl roots; scope to declared vars

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -14,7 +14,10 @@ shipped between releases. Forge has two cumulative migration steps:
 If you are coming from **v0.2.x or earlier**, run **both** steps in
 order — `forge migrate templates` first, then `forge migrate config`.
 If you are already on v0.3.x (HCL2 templates, YAML config), only the
-second step is required.
+second step is required. If you ran the steps **out of order** and
+ended up with v1 template syntax stranded in a `blueprint.hcl`-rooted
+registry, `forge migrate templates` (v0.4.1+) walks HCL-rooted
+blueprints too — re-run it against your registry to clean up.
 
 ## Migrating template syntax (v0.2.x → v0.3.x)
 

--- a/internal/migratecmd/rules.go
+++ b/internal/migratecmd/rules.go
@@ -75,8 +75,42 @@ var knownFuncs = map[string]any{
 // source-line info so the author can fix them by hand; the offending
 // region is emitted verbatim into the output as a best-effort fallback.
 //
+// Every `{{ .X }}` is translated to `${X}` regardless of whether `X`
+// is a declared variable — appropriate for the v0.2.x → v0.3.x cutover
+// where every `{{ }}` in a .tmpl file was forge syntax. For v0.4.x+
+// registries that mix forge variables with downstream-tool `{{ }}`
+// syntax (goreleaser, Helm), use RewriteTemplateScoped instead.
+//
 // The function is pure: it never touches the filesystem or network.
 func RewriteTemplate(name, src string) (string, []UntranslatedHit, error) {
+	return rewriteTemplate(name, src, nil)
+}
+
+// RewriteTemplateScoped is the variable-aware variant of RewriteTemplate.
+// Simple `{{ .name }}` actions whose name isn't in declared are emitted
+// verbatim — they're treated as downstream-tool syntax (goreleaser's
+// `{{ .ProjectName }}`, Helm's `{{ .Values.replicas }}`, etc.) rather
+// than v1 forge references. Chained field access (`{{ .a.b }}`) is
+// always emitted verbatim regardless of the scope, since forge
+// variables are single-level. Function calls and pipes always migrate
+// because they have no downstream-tool analogue.
+//
+// Passing a nil declared slice yields the same behavior as
+// RewriteTemplate (translate every field).
+func RewriteTemplateScoped(name, src string, declared []string) (string, []UntranslatedHit, error) {
+	var scope map[string]struct{}
+
+	if declared != nil {
+		scope = make(map[string]struct{}, len(declared))
+		for _, v := range declared {
+			scope[v] = struct{}{}
+		}
+	}
+
+	return rewriteTemplate(name, src, scope)
+}
+
+func rewriteTemplate(name, src string, scope map[string]struct{}) (string, []UntranslatedHit, error) {
 	normalised := normalisePathShorthand(src)
 
 	tree, err := parse.New(name).Parse(normalised, "{{", "}}", map[string]*parse.Tree{}, knownFuncs)
@@ -84,7 +118,13 @@ func RewriteTemplate(name, src string) (string, []UntranslatedHit, error) {
 		return "", nil, fmt.Errorf("parsing v1 template %q: %w", name, err)
 	}
 
-	w := newWalker(name, normalised)
+	var w *walker
+	if scope == nil {
+		w = newWalker(name, normalised)
+	} else {
+		w = newWalkerScoped(name, normalised, scope)
+	}
+
 	w.walkList(tree.Root)
 
 	return w.out.String(), w.hits, nil
@@ -175,10 +215,22 @@ type walker struct {
 	src  string
 	out  strings.Builder
 	hits []UntranslatedHit
+	// allowedVars scopes single-field `{{ .X }}` rewrites to declared
+	// forge variables. A nil map means "translate every field" — the
+	// legacy v0.2.x → v0.3.x behavior where every `{{ }}` was forge
+	// syntax. A non-nil map means: simple `{{ .name }}` actions whose
+	// name is absent from the map are emitted verbatim (they're
+	// downstream-tool syntax like goreleaser's `{{ .ProjectName }}` or
+	// Helm's `{{ .Values.replicas }}`, not v1 forge references).
+	allowedVars map[string]struct{}
 }
 
 func newWalker(name, src string) *walker {
 	return &walker{name: name, src: src}
+}
+
+func newWalkerScoped(name, src string, allowed map[string]struct{}) *walker {
+	return &walker{name: name, src: src, allowedVars: allowed}
 }
 
 func (w *walker) walkList(list *parse.ListNode) {
@@ -221,7 +273,20 @@ func (w *walker) walkNode(node parse.Node) {
 // walkAction translates a `{{ … }}` action node into a `${ … }` HCL
 // interpolation. The wrapped PipeNode is decomposed into nested function
 // calls when more than one command is present.
+//
+// When the walker carries a non-nil allowedVars scope, simple
+// `{{ .name }}` actions whose name isn't in the scope (including any
+// chained `{{ .a.b }}` reference, since forge variables never chain)
+// are emitted verbatim — they're downstream-tool syntax (goreleaser's
+// `{{ .ProjectName }}`, Helm's `{{ .Values.replicas }}`, etc.) that
+// must pass through the renderer untouched.
 func (w *walker) walkAction(n *parse.ActionNode) {
+	if w.allowedVars != nil && simpleField(n) && !w.fieldIsAllowed(n) {
+		w.out.WriteString(w.actionSource(n))
+
+		return
+	}
+
 	expr, ok := w.translatePipe(n.Pipe)
 	if !ok {
 		w.out.WriteString(n.String())
@@ -232,6 +297,71 @@ func (w *walker) walkAction(n *parse.ActionNode) {
 	w.out.WriteString("${")
 	w.out.WriteString(expr)
 	w.out.WriteString("}")
+}
+
+// actionSource returns the original source text for an action,
+// preserving the author's whitespace inside the `{{ }}`. parse.Node's
+// String() method rebuilds from the parse tree and strips internal
+// spacing — that's irrelevant for actions we're translating, but
+// matters for actions we're passing through verbatim because they're
+// destined for a downstream tool (Helm, goreleaser) that may be
+// whitespace-sensitive in expression contexts.
+//
+// ActionNode.Pos in the Go parse package points at the action body
+// (the `.` in `{{ .X }}`), not at the opening `{{` delimiter, so we
+// scan backwards to find the `{{` before slicing.
+func (w *walker) actionSource(n *parse.ActionNode) string {
+	pos := int(n.Pos)
+	if pos >= len(w.src) {
+		return n.String()
+	}
+
+	start := strings.LastIndex(w.src[:pos], "{{")
+	if start < 0 {
+		return n.String()
+	}
+
+	i := strings.Index(w.src[start:], "}}")
+	if i < 0 {
+		return n.String()
+	}
+
+	return w.src[start : start+i+2]
+}
+
+// simpleField reports whether the action is shaped `{{ .X }}` or
+// `{{ .X.Y... }}` — a single command with a single FieldNode argument.
+// Function calls (`{{ snakeCase .x }}`), pipes (`{{ .x | upper }}`),
+// and multi-command actions return false.
+func simpleField(n *parse.ActionNode) bool {
+	if n == nil || n.Pipe == nil || len(n.Pipe.Cmds) != 1 {
+		return false
+	}
+
+	cmd := n.Pipe.Cmds[0]
+	if len(cmd.Args) != 1 {
+		return false
+	}
+
+	_, ok := cmd.Args[0].(*parse.FieldNode)
+
+	return ok
+}
+
+// fieldIsAllowed reports whether the root identifier of a simple-field
+// action is in the allowedVars scope. Callers must verify the action
+// is a simple-field action first (via simpleField). Chained field
+// references (`{{ .a.b }}`) always return false — forge variables are
+// single-level, so any chain is downstream syntax.
+func (w *walker) fieldIsAllowed(n *parse.ActionNode) bool {
+	field, ok := n.Pipe.Cmds[0].Args[0].(*parse.FieldNode)
+	if !ok || len(field.Ident) != 1 {
+		return false
+	}
+
+	_, allowed := w.allowedVars[field.Ident[0]]
+
+	return allowed
 }
 
 // walkIf translates `{{ if cond }} … {{ else }} … {{ end }}` to the

--- a/internal/migratecmd/walk.go
+++ b/internal/migratecmd/walk.go
@@ -8,12 +8,15 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/donaldgifford/forge/internal/config"
 )
 
 const (
-	blueprintFileName = "blueprint.yaml"
-	registryFileName  = "registry.yaml"
-	tmplExtension     = ".tmpl"
+	blueprintFileName    = "blueprint.yaml"
+	blueprintHCLFileName = "blueprint.hcl"
+	registryFileName     = "registry.yaml"
+	tmplExtension        = ".tmpl"
 
 	apiVersionV2 = "v2"
 )
@@ -43,10 +46,20 @@ func runMigrate(opts *MigrateOpts) (*MigrateResult, error) {
 		return nil, fmt.Errorf("walking blueprints: %w", err)
 	}
 
+	// Collect the union of declared variables across all blueprints
+	// once, up front. The union scopes simple-field rewrites so the
+	// migrator doesn't mistakenly translate downstream-tool `{{ .X }}`
+	// patterns (goreleaser, Helm, etc.) that share v1's surface
+	// syntax. Per-blueprint scoping would be slightly more precise,
+	// but inherited `_defaults/` files commonly reference variables
+	// declared in only some blueprints, and the union avoids
+	// surprising "this is declared over there but not here" gaps.
+	declaredVars := collectDeclaredVars(blueprints)
+
 	covered := make(map[string]struct{})
 
 	for _, bpDir := range blueprints {
-		report, err := migrateBlueprint(bpDir, opts.DryRun)
+		report, err := migrateBlueprint(bpDir, declaredVars, opts.DryRun)
 		if err != nil {
 			return nil, fmt.Errorf("migrating %s: %w", bpDir, err)
 		}
@@ -60,7 +73,7 @@ func runMigrate(opts *MigrateOpts) (*MigrateResult, error) {
 
 	// 3. Migrate any .tmpl files under _defaults/ (registry-wide and
 	// category-level) that the per-blueprint walk didn't cover.
-	defaultHits, defaultFiles, err := migrateDefaults(abs, covered, opts.DryRun)
+	defaultHits, defaultFiles, err := migrateDefaults(abs, declaredVars, covered, opts.DryRun)
 	if err != nil {
 		return nil, fmt.Errorf("migrating _defaults: %w", err)
 	}
@@ -87,8 +100,10 @@ func runMigrate(opts *MigrateOpts) (*MigrateResult, error) {
 // migrateDefaults walks every _defaults/ directory under root and
 // rewrites .tmpl files the per-blueprint pass didn't already cover. The
 // covered set is used to dedupe — a _defaults dir nested *inside* a
-// blueprint already gets migrated by migrateBlueprint.
-func migrateDefaults(root string, covered map[string]struct{}, dryRun bool) ([]UntranslatedHit, []string, error) {
+// blueprint already gets migrated by migrateBlueprint. declared scopes
+// the rewriter to the union of declared variables across all
+// blueprints; nil means "translate every field" (legacy behavior).
+func migrateDefaults(root string, declared []string, covered map[string]struct{}, dryRun bool) ([]UntranslatedHit, []string, error) {
 	var (
 		hits  []UntranslatedHit
 		files []string
@@ -115,7 +130,7 @@ func migrateDefaults(root string, covered map[string]struct{}, dryRun bool) ([]U
 			return readErr
 		}
 
-		out, fileHits, rewriteErr := RewriteTemplate(path, string(src))
+		out, fileHits, rewriteErr := RewriteTemplateScoped(path, string(src), declared)
 		if rewriteErr != nil {
 			return fmt.Errorf("rewriting %s: %w", path, rewriteErr)
 		}
@@ -138,9 +153,116 @@ func migrateDefaults(root string, covered map[string]struct{}, dryRun bool) ([]U
 	return hits, files, err
 }
 
+// collectDeclaredVars returns the sorted union of declared variable
+// names across every blueprint in dirs. Blueprints with a
+// `blueprint.hcl` are loaded via config.LoadBlueprint; blueprints with
+// only a `blueprint.yaml` are parsed by hand from the YAML document
+// tree (since the v2 loader rejects YAML configs). Errors loading any
+// single blueprint are tolerated — the variable list just won't
+// include that blueprint's declarations. The result is used to scope
+// simple-field rewrites in .tmpl files so the migrator doesn't
+// translate downstream-tool `{{ .X }}` patterns (goreleaser,
+// Helm, etc.) that share v1's surface syntax.
+//
+// Returns nil when no declarations can be read from any blueprint,
+// which preserves the legacy "translate every field" behavior.
+func collectDeclaredVars(dirs []string) []string {
+	seen := make(map[string]struct{})
+
+	for _, dir := range dirs {
+		names := readDeclaredVars(dir)
+		for _, n := range names {
+			seen[n] = struct{}{}
+		}
+	}
+
+	if len(seen) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+
+	return out
+}
+
+// readDeclaredVars returns the declared variable names for a single
+// blueprint directory. Prefers blueprint.hcl when present; falls back
+// to a yaml.Node walk for blueprint.yaml (used during the v0.2.x →
+// v0.3.x migration before configs were moved to HCL).
+func readDeclaredVars(dir string) []string {
+	hclPath := filepath.Join(dir, blueprintHCLFileName)
+	if _, err := os.Stat(hclPath); err == nil {
+		bp, err := config.LoadBlueprint(hclPath)
+		if err != nil {
+			return nil
+		}
+
+		out := make([]string, 0, len(bp.Variables))
+		for _, v := range bp.Variables {
+			out = append(out, v.Name)
+		}
+
+		return out
+	}
+
+	yamlPath := filepath.Join(dir, blueprintFileName)
+
+	data, err := os.ReadFile(filepath.Clean(yamlPath))
+	if err != nil {
+		return nil
+	}
+
+	return extractYAMLVariableNames(data)
+}
+
+// extractYAMLVariableNames pulls variable names from a v1-shape
+// blueprint.yaml document via yaml.Node. The schema has a top-level
+// `variables:` sequence whose elements are mappings with a `name`
+// scalar. Returns nil on any parse failure — the migrator falls back
+// to "translate every field" in that case.
+func extractYAMLVariableNames(data []byte) []string {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil
+	}
+
+	root := documentRoot(&doc)
+	if root == nil {
+		return nil
+	}
+
+	vars := findMappingValue(root, "variables")
+	if vars == nil || vars.Kind != yaml.SequenceNode {
+		return nil
+	}
+
+	out := make([]string, 0, len(vars.Content))
+
+	for _, v := range vars.Content {
+		name := findMappingValue(v, "name")
+		if name == nil || name.Kind != yaml.ScalarNode || name.Value == "" {
+			continue
+		}
+
+		out = append(out, name.Value)
+	}
+
+	return out
+}
+
 // walkBlueprints returns every directory under root that contains a
-// blueprint.yaml file.
+// blueprint config file. Both v0.3.x `blueprint.yaml` and v0.4.x+
+// `blueprint.hcl` count as roots — registries that ran `forge migrate
+// config` before `forge migrate templates` (or that hand-authored an
+// HCL config from scratch) still need the per-blueprint .tmpl walks
+// applied even though no YAML config exists on disk. A directory with
+// both files (mid-migration) is reported once.
 func walkBlueprints(root string) ([]string, error) {
+	seen := make(map[string]struct{})
+
 	var out []string
 
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
@@ -148,11 +270,21 @@ func walkBlueprints(root string) ([]string, error) {
 			return err
 		}
 
-		if d.IsDir() || d.Name() != blueprintFileName {
+		if d.IsDir() {
 			return nil
 		}
 
-		out = append(out, filepath.Dir(path))
+		if d.Name() != blueprintFileName && d.Name() != blueprintHCLFileName {
+			return nil
+		}
+
+		dir := filepath.Dir(path)
+		if _, ok := seen[dir]; ok {
+			return nil
+		}
+
+		seen[dir] = struct{}{}
+		out = append(out, dir)
 
 		return nil
 	})
@@ -231,13 +363,89 @@ func renamePathShorthandDirs(root string, dryRun bool) ([]string, error) {
 	return out, nil
 }
 
-// migrateBlueprint runs the migration for one blueprint directory:
+// migrateBlueprint runs the migration for one blueprint directory.
+// Dispatches between the YAML and HCL paths: if `blueprint.yaml` is
+// present, the YAML path also rewrites the apiVersion check and the
+// expression fields (variable.default, condition.when, rename). The
+// HCL path only walks .tmpl files and renames template directories —
+// blueprint.hcl content is already HCL2. declared is the union of
+// declared variable names across the registry, used to scope
+// simple-field rewrites in .tmpl files.
+func migrateBlueprint(dir string, declared []string, dryRun bool) (*BlueprintReport, error) {
+	if _, err := os.Stat(filepath.Join(dir, blueprintFileName)); err == nil {
+		return migrateBlueprintYAML(dir, declared, dryRun)
+	}
+
+	return migrateBlueprintHCL(dir, declared, dryRun)
+}
+
+// migrateBlueprintHCL runs the .tmpl-only migration for a
+// blueprint.hcl-rooted blueprint. The HCL config itself is left
+// untouched (its expression fields are already HCL2). The `.tmpl`
+// rewrite logic is idempotent, so re-runs are safe: a fully-v2
+// `.tmpl` file rewrites to itself and the blueprint's status comes
+// back as "unchanged".
+func migrateBlueprintHCL(dir string, declared []string, dryRun bool) (*BlueprintReport, error) {
+	report := &BlueprintReport{Path: dir}
+
+	tmplFiles, err := findTemplateFiles(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	tmplOutputs := make(map[string][]byte, len(tmplFiles))
+
+	for _, tmplPath := range tmplFiles {
+		src, readErr := os.ReadFile(filepath.Clean(tmplPath))
+		if readErr != nil {
+			return nil, fmt.Errorf("reading %s: %w", tmplPath, readErr)
+		}
+
+		out, fileHits, rewriteErr := RewriteTemplateScoped(tmplPath, string(src), declared)
+		if rewriteErr != nil {
+			return nil, fmt.Errorf("rewriting %s: %w", tmplPath, rewriteErr)
+		}
+
+		tmplOutputs[tmplPath] = []byte(out)
+		report.UntranslatedHits = append(report.UntranslatedHits, fileHits...)
+
+		if string(src) != out {
+			report.FilesRewritten = append(report.FilesRewritten, tmplPath)
+		}
+	}
+
+	if dryRun {
+		return report, nil
+	}
+
+	for path, content := range tmplOutputs {
+		if err := os.WriteFile(path, content, 0o644); err != nil {
+			return nil, fmt.Errorf("writing %s: %w", path, err)
+		}
+	}
+
+	renamed, err := renamePathShorthandDirs(dir, dryRun)
+	if err != nil {
+		return nil, fmt.Errorf("renaming dirs: %w", err)
+	}
+
+	report.FilesRewritten = append(report.FilesRewritten, renamed...)
+
+	if len(report.FilesRewritten) > 0 {
+		report.Migrated = true
+	}
+
+	return report, nil
+}
+
+// migrateBlueprintYAML runs the legacy v0.2.x/v0.3.x migration path
+// for a blueprint.yaml-rooted blueprint:
 //  1. Read blueprint.yaml; if apiVersion is already v2, return AlreadyV2
 //     (the field still serves as an idempotence signal for re-runs of
 //     the templates migrator, even though the loader no longer reads it).
 //  2. Rewrite expression fields (variable.default, condition.when, rename).
 //  3. Rewrite all .tmpl files under the directory.
-func migrateBlueprint(dir string, dryRun bool) (*BlueprintReport, error) {
+func migrateBlueprintYAML(dir string, declared []string, dryRun bool) (*BlueprintReport, error) {
 	report := &BlueprintReport{Path: dir}
 	bpPath := filepath.Join(dir, blueprintFileName)
 
@@ -273,7 +481,7 @@ func migrateBlueprint(dir string, dryRun bool) (*BlueprintReport, error) {
 			return nil, fmt.Errorf("reading %s: %w", tmplPath, readErr)
 		}
 
-		out, fileHits, rewriteErr := RewriteTemplate(tmplPath, string(src))
+		out, fileHits, rewriteErr := RewriteTemplateScoped(tmplPath, string(src), declared)
 		if rewriteErr != nil {
 			return nil, fmt.Errorf("rewriting %s: %w", tmplPath, rewriteErr)
 		}

--- a/internal/migratecmd/walk_test.go
+++ b/internal/migratecmd/walk_test.go
@@ -187,3 +187,147 @@ func TestRunMigrate_AlreadyV2Skips(t *testing.T) {
 	assert.True(t, result.Blueprints[0].AlreadyV2)
 	assert.False(t, result.Blueprints[0].Migrated)
 }
+
+// TestRunMigrate_HCLRootedBlueprint covers the case where a registry
+// has already been through `forge migrate config` (so its config
+// files are blueprint.hcl, not blueprint.yaml) but still has v1
+// template syntax stranded in .tmpl files. Surfaced by
+// donaldgifford/forge-registry — running `migrate config` before
+// `migrate templates` left v1 `{{ .project_name }}` syntax in 15
+// files because the walker only matched `blueprint.yaml`-rooted
+// directories.
+func TestRunMigrate_HCLRootedBlueprint(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	bpDir := filepath.Join(root, "go", "api")
+	require.NoError(t, os.MkdirAll(filepath.Join(bpDir, "{{project_name}}"), 0o755))
+
+	hclConfig := []byte(`name        = "go-api"
+description = "Go API"
+version     = "1.0.0"
+
+variable "project_name" {
+  type = "string"
+}
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(bpDir, "blueprint.hcl"), hclConfig, 0o644))
+
+	tmpl := []byte("# {{ .project_name }}\nmodule {{ .project_name }}\n")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(bpDir, "{{project_name}}", "README.md.tmpl"),
+		tmpl, 0o644,
+	))
+
+	result, err := migratecmd.RunMigrate(&migratecmd.MigrateOpts{Path: root, Force: true})
+	require.NoError(t, err)
+	require.Len(t, result.Blueprints, 1)
+
+	report := result.Blueprints[0]
+	assert.True(t, report.Migrated, "HCL-rooted blueprint with v1 .tmpl content should migrate")
+	assert.False(t, report.AlreadyV2, "AlreadyV2 only applies to YAML configs with apiVersion: v2")
+
+	// Template content rewritten in place.
+	renamedTmpl := filepath.Join(bpDir, "${project_name}", "README.md.tmpl")
+	got, err := os.ReadFile(renamedTmpl)
+	require.NoError(t, err)
+	assert.Equal(t, "# ${project_name}\nmodule ${project_name}\n", string(got))
+
+	// blueprint.hcl is untouched — its expression fields are already
+	// HCL2; the migrator has no business rewriting them.
+	hclAfter, err := os.ReadFile(filepath.Join(bpDir, "blueprint.hcl"))
+	require.NoError(t, err)
+	assert.Equal(t, string(hclConfig), string(hclAfter), "blueprint.hcl should not be modified")
+
+	// Original {{project_name}} directory is gone.
+	_, err = os.Stat(filepath.Join(bpDir, "{{project_name}}"))
+	assert.True(t, os.IsNotExist(err), "v1-shape template directory should be renamed")
+}
+
+// TestRunMigrate_HCLRootedLeavesDownstreamSyntaxAlone pins the
+// variable-scoped rewriter: `{{ .ProjectName }}` and `{{ .Env.FOO }}`
+// in a .goreleaser-style template must pass through verbatim — they
+// are goreleaser variables, not forge variables. Forge variables
+// (single-level, snake_case identifiers declared in blueprint.hcl)
+// still rewrite normally.
+func TestRunMigrate_HCLRootedLeavesDownstreamSyntaxAlone(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	bpDir := filepath.Join(root, "go", "ext")
+	require.NoError(t, os.MkdirAll(bpDir, 0o755))
+
+	hclConfig := []byte(`name = "go-ext"
+
+variable "project_name" {
+  type = "string"
+}
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(bpDir, "blueprint.hcl"), hclConfig, 0o644))
+
+	// .goreleaser.yml.tmpl-shaped content: forge vars are v1 dot-form
+	// (need migration); goreleaser's CamelCase fields and Env chain
+	// must be preserved as literal text.
+	goreleaserTmpl := []byte(`builds:
+  - id: {{ .project_name }}
+    binary: {{ .project_name }}
+
+archives:
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
+
+signs:
+  - args: ['--local-user', '{{ .Env.GPG_FINGERPRINT }}']
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(bpDir, ".goreleaser.yml.tmpl"), goreleaserTmpl, 0o644))
+
+	_, err := migratecmd.RunMigrate(&migratecmd.MigrateOpts{Path: root, Force: true})
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(filepath.Join(bpDir, ".goreleaser.yml.tmpl"))
+	require.NoError(t, err)
+
+	want := `builds:
+  - id: ${project_name}
+    binary: ${project_name}
+
+archives:
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
+
+signs:
+  - args: ['--local-user', '{{ .Env.GPG_FINGERPRINT }}']
+`
+	assert.Equal(t, want, string(got))
+}
+
+// TestRunMigrate_HCLRootedIdempotent covers re-running the migrator
+// against a fully-v2 HCL-rooted blueprint: the .tmpl rewriter is
+// idempotent so the run reports unchanged status.
+func TestRunMigrate_HCLRootedIdempotent(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	bpDir := filepath.Join(root, "go", "api")
+	require.NoError(t, os.MkdirAll(filepath.Join(bpDir, "${project_name}"), 0o755))
+
+	hclConfig := []byte(`name = "go-api"
+
+variable "project_name" {
+  type = "string"
+}
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(bpDir, "blueprint.hcl"), hclConfig, 0o644))
+
+	tmpl := []byte("# ${project_name}\n")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(bpDir, "${project_name}", "README.md.tmpl"),
+		tmpl, 0o644,
+	))
+
+	result, err := migratecmd.RunMigrate(&migratecmd.MigrateOpts{Path: root, Force: true})
+	require.NoError(t, err)
+	require.Len(t, result.Blueprints, 1)
+
+	report := result.Blueprints[0]
+	assert.False(t, report.Migrated, "fully-v2 HCL blueprint should report unchanged on re-run")
+	assert.Empty(t, report.FilesRewritten)
+}


### PR DESCRIPTION
## Summary

Surfaced when `forge create go/ext` against forge-registry main failed with `Unknown variable; There is no variable named "TARGETOS"`. Two compounding migrator gaps:

1. **`walkBlueprints` only matched `blueprint.yaml`-rooted directories.** After IMPL-0005 every valid blueprint is rooted at `blueprint.hcl`, so the migrator silently found zero blueprints and only walked the top-level `_defaults`. Registries that ran `forge migrate config` before `forge migrate templates` (or that hand-authored an HCL config from scratch) had no path to clean up stranded v1 syntax.

2. **The rewriter translated every `{{ .X }}` regardless of whether `X` was declared.** Correct for the v0.2.x → v0.3.x cutover (every `{{ }}` in a `.tmpl` file was forge syntax) but actively wrong for v0.4.x registries that mix forge variables with downstream-tool `{{ }}` syntax — the migrator would corrupt goreleaser's `{{ .ProjectName }}` / `{{ .Env.GPG_FINGERPRINT }}`, Helm's `{{ .Values.replicas }}`, etc.

## Changes

- **`walkBlueprints`** matches either `blueprint.yaml` or `blueprint.hcl`; dedupes by directory.
- **`migrateBlueprintHCL`** (new): walks `.tmpl` files and renames template directories; doesn't touch `blueprint.hcl` itself (already HCL2).
- **`RewriteTemplateScoped(name, src, declared)`** (new): variable-aware variant of `RewriteTemplate`. Simple `{{ .name }}` actions whose name isn't in `declared` are emitted verbatim. Chained `{{ .a.b }}` is always emitted verbatim (forge variables never chain). Function calls and pipes always migrate (no downstream analogue).
- **`collectDeclaredVars`** (new): pre-pass that reads variable names from every blueprint config (HCL via `config.LoadBlueprint`, YAML via `yaml.Node` walk). The union is passed to per-blueprint walks and to `migrateDefaults` so inherited `_defaults/` files are scoped consistently.
- Verbatim-emission for skipped actions slices the original source to preserve the author's whitespace inside `{{ }}` (parse.Node's `String()` rebuilds and strips internal spacing).
- `MIGRATION.md` notes the v0.4.1+ re-run path for stranded v1 syntax.

## Test plan

- [x] `make ci` green.
- [x] New tests:
  - `TestRunMigrate_HCLRootedBlueprint` — basic HCL-rooted walk.
  - `TestRunMigrate_HCLRootedLeavesDownstreamSyntaxAlone` — pins the goreleaser/`{{ .Env.X }}` scoping behavior.
  - `TestRunMigrate_HCLRootedIdempotent` — re-runs against an already-v2 tree report unchanged.
- [x] Verified end-to-end against forge-registry `main` (in a worktree): migrator catches all 16 v1-syntax files across `go/`, `rust/`, and shared `_defaults/`, while leaving goreleaser's `{{ .ProjectName }}` / `{{ .Os }}` / `{{ .Env.GPG_FINGERPRINT }}` etc. intact.

## Known remaining manual step

Downstream-tool `${VAR}` patterns (Docker buildx `${TARGETOS}`, docker bake `${REGISTRY}`, etc.) still need manual `\$\$`-escaping — the migrator can't disambiguate forge-vs-downstream `${...}` from syntax alone. `forge create` surfaces each unescaped occurrence with a precise `file:line:col` error, and the fix pattern is documented in `docs/MIGRATION.md` ("Literal `${...}` for downstream tools").

🤖 Generated with [Claude Code](https://claude.com/claude-code)