### PR TITLE
feat: variable input via --var-file (IMPL-0008)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,15 @@ packages:
   PartialContent on the eager fields and hand-decode the dynamic `variables`
   block; `cty.Value` in memory with typed coercion via `lockfile.ToCtyValues`
   using declared variable types
+- **internal/varsfile/** — `--var-file` input loading (IMPL-0008). Single
+  exported `Load(paths, declared)` that parses one or more `.forge-vars.hcl`
+  files (strict `.hcl` extension, attributes-only, no functions or
+  traversals), composes them left-to-right with last-wins semantics, and
+  coerces values against the blueprint's declared variable types via
+  `cty/convert`. Returns the resolved `map[string]cty.Value` plus an
+  `unknown` slice for keys not declared in `blueprint.hcl` (warning, not
+  error). Used by `create.Run` and `sync.Run`; `forge check` rejects the
+  flag outright with an actionable error.
 - **internal/check/** — Drift detection comparing lockfile vs local files
 - **internal/hooks/** — Post-create hook execution with context cancellation
 - **internal/list/** — Blueprint listing with tag filtering
@@ -118,6 +127,22 @@ See `docs/impl/0002-mvp-cli-gap-closure.md` for the full history and rationale.
   `internal/lockfile/lock.go` surface this path inline — they include
   the literal `go install github.com/donaldgifford/forge@v0.4.1`
   invocation per IMPL-0007 OQ-3.
+- **`--var-file` (IMPL-0008 / DESIGN-0005).** Repeatable flag on
+  `forge create` and `forge sync` that loads variable values from
+  one or more `.forge-vars.hcl` files; mutually exclusive with
+  `--set` on a single invocation (manual check in
+  `cmd/create.go::requireSingleVarSource`, not Cobra's generic
+  `MarkFlagsMutuallyExclusive` — see IMPL-0008 OQ-2 for the
+  rationale). On `forge sync`, `--var-file` requires `--force`
+  because it rewrites the lockfile with the new resolved values
+  (`cmd/sync.go::requireForceForVarFile`). `forge check` rejects
+  the flag outright with an actionable error pointing at
+  `forge sync --var-file FILE --force --dry-run`
+  (`cmd/check.go::rejectVarFileOnCheck`). Process substitution
+  (`<(...)`) is **not** supported — strict `.hcl` extension check
+  on the path (IMPL-0008 OQ-8); the documented escape hatch is the
+  tempfile pattern. Unknown keys surface as a warning, not an
+  error; type-coercion failures abort before any side effects.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,19 @@ make build
 ## Quick Start
 
 ```bash
-# Create a project from a blueprint
+# Create a project from a blueprint, with ad-hoc CLI overrides
 forge create go/api --set project_name=my-service --set go_module=github.com/me/my-service
+
+# Or load variable values from an HCL vars file (preferred for non-trivial inputs)
+cat > my-svc.forge-vars.hcl <<'EOF'
+project_name = "my-service"
+go_module    = "github.com/me/my-service"
+replicas     = 3
+EOF
+forge create go/api --var-file ./my-svc.forge-vars.hcl
+
+# --var-file is repeatable; later files win on key collision.
+# --var-file and --set are mutually exclusive on a single invocation.
 
 # List available blueprints
 forge list --registry /path/to/registry
@@ -69,12 +80,12 @@ forge cache clean
 
 | Command | Description |
 |---------|-------------|
-| `forge create <blueprint>` | Scaffold a new project from a blueprint |
+| `forge create <blueprint>` | Scaffold a new project from a blueprint (`--set`, `--var-file`) |
 | `forge list` | List available blueprints in a registry |
 | `forge search <query>` | Search blueprints by name, description, or tags |
 | `forge info <blueprint.hcl>` | Show detailed blueprint information |
-| `forge check` | Check project for drift against the source blueprint |
-| `forge sync` | Sync project files with the latest blueprint version |
+| `forge check` | Check project for drift against the source blueprint (`--var-file` rejected) |
+| `forge sync` | Sync project files with the latest blueprint version (`--var-file` requires `--force`) |
 | `forge init` | Initialize a new blueprint |
 | `forge registry init <path>` | Scaffold a new blueprint registry |
 | `forge registry blueprint` | Scaffold a new blueprint in a registry |

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 
@@ -13,6 +14,7 @@ import (
 var (
 	checkOutputFormat string
 	checkRegistryDir  string
+	checkVarFiles     []string
 )
 
 var checkCmd = &cobra.Command{
@@ -32,10 +34,17 @@ upstream changes. Statuses: modified-locally, upstream-changed, both-changed.`,
 func init() {
 	checkCmd.Flags().StringVarP(&checkOutputFormat, "output", "o", "text", "output format (text, json)")
 	checkCmd.Flags().StringVar(&checkRegistryDir, "registry-dir", "", "registry source for upstream comparison")
+	checkCmd.Flags().StringArrayVar(&checkVarFiles, "var-file", nil,
+		"not supported on `forge check`; registered so the rejection error is actionable. "+
+			"Use `forge sync --var-file FILE --force --dry-run` to preview drift against alternative values.")
 	rootCmd.AddCommand(checkCmd)
 }
 
 func runCheck(cmd *cobra.Command, _ []string) error {
+	if err := rejectVarFileOnCheck(checkVarFiles); err != nil {
+		return err
+	}
+
 	logger := slog.Default()
 
 	resolvedRegistryDir, cleanup, err := resolveCheckRegistry(cmd.Context(), logger)
@@ -57,6 +66,24 @@ func runCheck(cmd *cobra.Command, _ []string) error {
 	_, err = check.Run(opts)
 
 	return err
+}
+
+// rejectVarFileOnCheck enforces the IMPL-0008 OQ-5 contract:
+// `forge check` is a drift-detection command that reads variables
+// from the lockfile only. Vars-file input has no meaningful semantic
+// here, so we reject early with an actionable message that points at
+// the supported workflow (`forge sync --var-file --force --dry-run`).
+func rejectVarFileOnCheck(varFilePaths []string) error {
+	if len(varFilePaths) == 0 {
+		return nil
+	}
+
+	return errors.New(
+		"--var-file is not supported on `forge check` " +
+			"(check is drift-detection and reads variables from the lockfile only); " +
+			"to preview drift against alternative values, use " +
+			"`forge sync --var-file FILE --force --dry-run`",
+	)
 }
 
 // resolveCheckRegistry resolves the --registry-dir flag for check.

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRejectVarFileOnCheck covers the IMPL-0008 OQ-5 contract:
+// `forge check` is lockfile-driven by design, so --var-file has no
+// meaningful drift-detection semantic. The flag is registered solely
+// so the rejection message is actionable (rather than Cobra's generic
+// "unknown flag" diagnostic). This test pins the exact wording the
+// CLI surfaces.
+func TestRejectVarFileOnCheck(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		varFiles  []string
+		wantError bool
+	}{
+		{
+			name:      "no var-files passes",
+			varFiles:  nil,
+			wantError: false,
+		},
+		{
+			name:      "empty slice passes",
+			varFiles:  []string{},
+			wantError: false,
+		},
+		{
+			name:      "single var-file rejected",
+			varFiles:  []string{"vars.forge-vars.hcl"},
+			wantError: true,
+		},
+		{
+			name:      "multiple var-files rejected",
+			varFiles:  []string{"a.forge-vars.hcl", "b.forge-vars.hcl"},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := rejectVarFileOnCheck(tt.varFiles)
+
+			if tt.wantError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "--var-file is not supported on `forge check`")
+				assert.Contains(t, err.Error(), "`forge sync --var-file FILE --force --dry-run`")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -19,6 +20,7 @@ import (
 
 var (
 	setVars     []string
+	varFiles    []string
 	outputDir   string
 	useDefault  bool
 	noHooks     bool
@@ -41,6 +43,10 @@ as the blueprint registry source.`,
 
 func init() {
 	createCmd.Flags().StringArrayVar(&setVars, "set", nil, "set a variable value (key=value, can be repeated)")
+	createCmd.Flags().StringArrayVar(&varFiles, "var-file", nil,
+		"load variable values from an HCL document (.hcl extension required). "+
+			"Repeatable; later files override earlier ones on key collision. "+
+			"Mutually exclusive with --set.")
 	createCmd.Flags().StringVarP(&outputDir, "output-dir", "o", "", "target output directory")
 	createCmd.Flags().StringVar(&registryDir, "registry-dir", "", "path or URL to the blueprint registry")
 	createCmd.Flags().BoolVar(&useDefault, "defaults", false, "use all default values without prompting")
@@ -50,6 +56,10 @@ func init() {
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
+	if err := requireSingleVarSource(setVars, varFiles); err != nil {
+		return err
+	}
+
 	overrides := parseOverrides(setVars)
 	logger := slog.Default()
 	blueprintRef := args[0]
@@ -91,6 +101,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		RegistryURL:        regURL,
 		DefaultRegistryURL: defaultURL,
 		Overrides:          overrides,
+		VarsFiles:          varFiles,
 		UseDefaults:        useDefault,
 		NoHooks:            noHooks,
 		ForceCreate:        forceCreate,
@@ -104,9 +115,33 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	w := ui.NewWriter(noColor)
+
+	if len(result.UnknownVarsFileKeys) > 0 {
+		w.Warningf(
+			"--var-file declared values for variable(s) not in this blueprint: %s",
+			strings.Join(result.UnknownVarsFileKeys, ", "),
+		)
+	}
+
 	w.Successf("Created project %q in %s (%d files)", result.Blueprint, result.OutputDir, result.FilesCreated)
 
 	return nil
+}
+
+// requireSingleVarSource enforces the IMPL-0008 OQ-2 mutual-exclusion
+// rule between --set and --var-file. Both can be empty; both being
+// non-empty is the only failure mode.
+func requireSingleVarSource(setFlags, varFilePaths []string) error {
+	if len(setFlags) == 0 || len(varFilePaths) == 0 {
+		return nil
+	}
+
+	return errors.New(
+		"--var-file and --set cannot be combined. " +
+			"Use one input source per invocation:\n" +
+			"  - For one-off overrides: forge create … --set k=v\n" +
+			"  - For multiple values:   forge create … --var-file path/to/foo.forge-vars.hcl",
+	)
 }
 
 // resolveFromConfig resolves a registry from global config when --registry-dir

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRequireSingleVarSource_MutualExclusion covers the IMPL-0008
+// OQ-2 contract: --set and --var-file cannot both be set on the
+// same invocation. The check is intentionally a manual one (not
+// Cobra's MarkFlagsMutuallyExclusive) because DESIGN-0005's
+// error message is more actionable than Cobra's generic phrasing.
+func TestRequireSingleVarSource_MutualExclusion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		setFlags  []string
+		varFiles  []string
+		wantError bool
+	}{
+		{
+			name:      "both empty",
+			setFlags:  nil,
+			varFiles:  nil,
+			wantError: false,
+		},
+		{
+			name:      "only --set",
+			setFlags:  []string{"k=v"},
+			varFiles:  nil,
+			wantError: false,
+		},
+		{
+			name:      "only --var-file",
+			setFlags:  nil,
+			varFiles:  []string{"a.forge-vars.hcl"},
+			wantError: false,
+		},
+		{
+			name:      "both set",
+			setFlags:  []string{"k=v"},
+			varFiles:  []string{"a.forge-vars.hcl"},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := requireSingleVarSource(tt.setFlags, tt.varFiles)
+
+			if tt.wantError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "--var-file and --set cannot be combined")
+				assert.Contains(t, err.Error(), "one input source per invocation")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -20,6 +22,7 @@ var (
 	syncFileFilter  string
 	syncRegistryDir string
 	syncRef         string
+	syncVarFiles    []string
 )
 
 var syncCmd = &cobra.Command{
@@ -36,14 +39,22 @@ Use --ref to sync against a specific registry version.`,
 
 func init() {
 	syncCmd.Flags().BoolVar(&syncDryRun, "dry-run", false, "print what would change without writing")
-	syncCmd.Flags().BoolVarP(&syncForce, "force", "f", false, "skip confirmation prompts")
+	syncCmd.Flags().BoolVarP(&syncForce, "force", "f", false, "skip confirmation prompts; required when --var-file rewrites the lockfile")
 	syncCmd.Flags().StringVar(&syncFileFilter, "file", "", "sync only a specific file path")
 	syncCmd.Flags().StringVar(&syncRegistryDir, "registry-dir", "", "override registry source (local path or go-getter URL)")
 	syncCmd.Flags().StringVar(&syncRef, "ref", "", "sync against a specific registry version/ref")
+	syncCmd.Flags().StringArrayVar(&syncVarFiles, "var-file", nil,
+		"load variable values from an HCL document (.hcl extension required). "+
+			"Repeatable; later files override earlier ones on key collision. "+
+			"Requires --force because applying values to a sync rewrites the lockfile.")
 	rootCmd.AddCommand(syncCmd)
 }
 
 func runSync(cmd *cobra.Command, _ []string) error {
+	if err := requireForceForVarFile(syncVarFiles, syncForce); err != nil {
+		return err
+	}
+
 	logger := slog.Default()
 	w := ui.NewWriter(noColor)
 	projectDir := "."
@@ -94,11 +105,19 @@ func runSync(cmd *cobra.Command, _ []string) error {
 		DryRun:      syncDryRun,
 		Force:       syncForce,
 		FileFilter:  syncFileFilter,
+		VarsFiles:   syncVarFiles,
 	}
 
 	result, err := forgesync.Run(opts)
 	if err != nil {
 		return err
+	}
+
+	if len(result.UnknownVarsFileKeys) > 0 {
+		w.Warningf(
+			"--var-file declared values for variable(s) not in this blueprint: %s",
+			strings.Join(result.UnknownVarsFileKeys, ", "),
+		)
 	}
 
 	printSyncSummary(w, result)
@@ -173,6 +192,23 @@ func cleanupDir(logger *slog.Logger, dir string) {
 	if err := os.RemoveAll(dir); err != nil {
 		logger.Warn("failed to clean up temp directory", "dir", dir, "error", err)
 	}
+}
+
+// requireForceForVarFile enforces the IMPL-0008 OQ-4 contract on
+// sync: --var-file rewrites the lockfile with the new resolved
+// values, so the caller must pass --force to acknowledge that
+// side effect. Returning early when no var-file paths were supplied
+// keeps the no-op sync path unchanged.
+func requireForceForVarFile(varFilePaths []string, force bool) error {
+	if len(varFilePaths) == 0 || force {
+		return nil
+	}
+
+	return errors.New(
+		"--var-file on `forge sync` rewrites the lockfile with the new resolved values. " +
+			"Pass --force to confirm:\n" +
+			"  forge sync … --var-file FILE --force",
+	)
 }
 
 func printSyncSummary(w *ui.Writer, result *forgesync.Result) {

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -484,6 +484,10 @@ keep operating against legacy lockfiles.
 
 ## Variable input: preferred pattern (v0.6+)
 
+> **No migration required** — this section is *guidance* for new
+> invocations on v0.6+, not a required upgrade step. Existing
+> `--set` users keep working unchanged.
+
 `--set key=value` is still supported for ad-hoc CLI overrides, but
 **non-trivial inputs should live in a `.forge-vars.hcl` file** loaded
 via `--var-file`. The file is plain HCL, plays nicely with version

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -482,6 +482,56 @@ There is no "downgrade" path from `.forge-lock.hcl` back to
 `.forge-lock.yaml` — pin the forge binary to v0.4.1 if you need to
 keep operating against legacy lockfiles.
 
+## Variable input: preferred pattern (v0.6+)
+
+`--set key=value` is still supported for ad-hoc CLI overrides, but
+**non-trivial inputs should live in a `.forge-vars.hcl` file** loaded
+via `--var-file`. The file is plain HCL, plays nicely with version
+control and CI/CD pipelines, and supports the same scalar types
+declared in `blueprint.hcl` (string / number / bool / list / map).
+
+```hcl
+# ./my-svc.forge-vars.hcl
+project_name = "mockta-staging"
+replicas     = 3
+tags         = ["beta", "staging"]
+```
+
+```sh
+forge create go/ext --var-file ./my-svc.forge-vars.hcl
+```
+
+`--var-file` is repeatable; later files win on key collision. The
+flag is mutually exclusive with `--set` on any single invocation —
+the CLI rejects the combination with a clear message.
+
+**Inline overrides (tempfile pattern).** Process substitution is *not*
+supported (forge enforces a strict `.hcl` extension on the path).
+The supported escape hatch is a tempfile:
+
+```sh
+cat > /tmp/override.forge-vars.hcl <<EOF
+project_name = "mockta-staging"
+EOF
+forge create go/ext \
+  --var-file ./base.forge-vars.hcl \
+  --var-file /tmp/override.forge-vars.hcl
+```
+
+**On `forge sync`.** `--var-file` requires `--force` because it
+rewrites the lockfile with the new resolved values. Type-coercion
+errors abort the sync before any files are touched; unknown keys
+surface as a warning, not an error.
+
+**On `forge check`.** `--var-file` is rejected — `forge check` is a
+drift-detection command that reads variables from the lockfile only.
+Use `forge sync --var-file FILE --force --dry-run` to preview drift
+against alternative values.
+
+See [DESIGN-0005](design/0005-variable-input-via-vars-file.md) for
+the contract and [IMPL-0008](impl/0008-variable-input-via-vars-file.md)
+for the implementation details.
+
 ## Troubleshooting
 
 ### `apiVersion v1 is no longer supported`

--- a/docs/design/0005-variable-input-via-vars-file.md
+++ b/docs/design/0005-variable-input-via-vars-file.md
@@ -48,7 +48,9 @@ groundwork for object/list/map variable types (see RFC-0002).
 ### Goals
 
 - Provide a file-based alternative to `--set` for passing variable
-  values into `forge create` / `forge sync` / `forge check`.
+  values into `forge create` and `forge sync`. (`forge check`
+  registers the flag solely to emit a clear rejection error — see
+  OQ-5 for the rationale.)
 - Use HCL2 as the file format so the input grammar matches the rest
   of forge (blueprint.hcl, registry.hcl) and naturally handles nested
   structures when object/list/map types eventually land.
@@ -374,8 +376,10 @@ No release-notes pressure since the feature is additive.
   work — IMPL-0008 settled on a strict `.hcl` extension check on
   the input path, and `/dev/fd/63`-style paths from `<(...)` fail
   that check. The documented escape hatch is the *tempfile pattern*
-  (see [Mutual Exclusion](#mutual-exclusion-with---set) above and
-  the README example).
+  (see the tempfile example in
+  [Mutual Exclusion](#mutual-exclusion-with---set) above, plus
+  [MIGRATION.md § Variable input: preferred pattern](../MIGRATION.md#variable-input-preferred-pattern-v06)
+  for the user-facing walkthrough).
 
 ## References
 

--- a/docs/design/0005-variable-input-via-vars-file.md
+++ b/docs/design/0005-variable-input-via-vars-file.md
@@ -227,16 +227,24 @@ Rationale:
   ordering on the command line.
 
 Users who want to override a single field of a vars-file-driven
-scaffold should compose with a second `--var-file`:
+scaffold should compose with a second `--var-file` pointed at a
+tempfile:
 
 ```sh
+cat > /tmp/override.forge-vars.hcl <<EOF
+project_name = "mockta-staging"
+EOF
 forge create go/ext \
   --var-file ./base.forge-vars.hcl \
-  --var-file <(echo 'project_name = "mockta-staging"')
+  --var-file /tmp/override.forge-vars.hcl
 ```
 
-The `<(...)` process substitution gives a clean inline override path
-for one-off cases without breaking the "files only" model.
+The tempfile pattern keeps the "files only" model intact while still
+giving a clean one-off override path. Process substitution
+(`<(...)`) is **not supported** — IMPL-0008 OQ-8 settled on a strict
+`.hcl` extension check, and `/dev/fd/63`-style paths from
+`<(...)` fail that check (see the
+[Mutual Exclusion](#mutual-exclusion-with---set) discussion below).
 
 ### Lockfile Integration
 
@@ -360,9 +368,14 @@ No release-notes pressure since the feature is additive.
   `<(echo 'k = v')` pattern works but isn't discoverable. Worth a
   README example, or do we revisit and allow a narrow `--set` +
   `--var-file` combination after all? **Decision: No combo.** Keep
-  the mutual exclusion clean. Document the process-substitution
-  pattern in the README; revisit only if real-world friction
-  surfaces.
+  the mutual exclusion clean. Document the override pattern in the
+  README; revisit only if real-world friction surfaces.
+  **Superseded by IMPL-0008 OQ-8:** process substitution does *not*
+  work — IMPL-0008 settled on a strict `.hcl` extension check on
+  the input path, and `/dev/fd/63`-style paths from `<(...)` fail
+  that check. The documented escape hatch is the *tempfile pattern*
+  (see [Mutual Exclusion](#mutual-exclusion-with---set) above and
+  the README example).
 
 ## References
 

--- a/docs/impl/0008-variable-input-via-vars-file.md
+++ b/docs/impl/0008-variable-input-via-vars-file.md
@@ -1,7 +1,7 @@
 ---
 id: IMPL-0008
 title: "Variable input via vars file"
-status: Draft
+status: Accepted
 author: Donald Gifford
 created: 2026-05-19
 ---
@@ -9,7 +9,7 @@ created: 2026-05-19
 
 # IMPL 0008: Variable input via vars file
 
-**Status:** Draft
+**Status:** Accepted
 **Author:** Donald Gifford
 **Date:** 2026-05-19
 
@@ -589,7 +589,13 @@ actionable (DESIGN-0005-aligned), rather than Cobra's generic
     issue when this PR lands). Tracked in the IMPL document and in
     the release notes' "Before you cut" checklist.
 
-- [ ] **E.6 docz-reviewer pass on the doc changes.**
+- [x] **E.6 docz-reviewer pass on the doc changes.**
+  - Reviewer pass completed; addressed the must-fix items
+    (DESIGN-0005 dead link reference and Goals-section
+    silent omission of `forge check` rejection) and the
+    should-improve items (MIGRATION.md "no migration required"
+    note, release-notes redundancy collapse, `mkdocs build`
+    line added to the "Before you cut" checklist).
 
 #### Success Criteria
 

--- a/docs/impl/0008-variable-input-via-vars-file.md
+++ b/docs/impl/0008-variable-input-via-vars-file.md
@@ -544,7 +544,7 @@ actionable (DESIGN-0005-aligned), rather than Cobra's generic
 
 #### Tasks
 
-- [ ] **E.1 Update `docs/MIGRATION.md`.**
+- [x] **E.1 Update `docs/MIGRATION.md`.**
   - New "Preferred input pattern" note (not deprecating `--set`,
     recommending `.forge-vars.hcl` for non-trivial cases).
   - **Do NOT document the process-substitution pattern** that
@@ -561,31 +561,33 @@ actionable (DESIGN-0005-aligned), rather than Cobra's generic
       --var-file /tmp/override.forge-vars.hcl
     ```
 
-- [ ] **E.1b Update `docs/design/0005-variable-input-via-vars-file.md`.**
+- [x] **E.1b Update `docs/design/0005-variable-input-via-vars-file.md`.**
   - Replace the process-substitution example with the tempfile
     pattern (parity with E.1).
   - Add a note at the bottom of the Mutual Exclusion section
     cross-referencing IMPL-0008 OQ-8 for the rationale.
 
-- [ ] **E.2 Update `README.md`.**
+- [x] **E.2 Update `README.md`.**
   - Quick Start: add a `.forge-vars.hcl` example alongside the
     existing `--set` example.
   - Commands table: note `--var-file` on create/sync/check.
 
-- [ ] **E.3 Update `CLAUDE.md`.**
+- [x] **E.3 Update `CLAUDE.md`.**
   - Architecture entries: add `internal/varsfile/` package.
   - CLI Design Decisions: add the `--var-file` / `--set` mutual
     exclusion convention.
 
-- [ ] **E.4 Release notes.**
+- [x] **E.4 Release notes.**
   - File: `docs/release-notes/v0.X.0-vars-file.md` (new — version
     set when work lands).
   - Highlight the additive feature; document the mutual-exclusion
     rule and the process-substitution escape hatch.
 
-- [ ] **E.5 Update forge-registry blueprint READMEs (downstream).**
-  - Not in this repo — note as a follow-up issue against
-    `github.com/donaldgifford/forge-registry`.
+- [x] **E.5 Update forge-registry blueprint READMEs (downstream).**
+  - Not in this repo — noted as a follow-up against
+    `github.com/donaldgifford/forge-registry` (to be filed as an
+    issue when this PR lands). Tracked in the IMPL document and in
+    the release notes' "Before you cut" checklist.
 
 - [ ] **E.6 docz-reviewer pass on the doc changes.**
 

--- a/docs/impl/0008-variable-input-via-vars-file.md
+++ b/docs/impl/0008-variable-input-via-vars-file.md
@@ -264,12 +264,12 @@ exclusion with `--set`, integration with `prompt.CollectVariables`.
 
 #### Tasks
 
-- [ ] **B.1 Add the `--var-file` flag to `forge create`.**
+- [x] **B.1 Add the `--var-file` flag to `forge create`.**
   - File: `cmd/create.go` (modify around lines 20–50).
   - Declare `varFiles []string` alongside the existing `setVars`.
   - Register: `createCmd.Flags().StringArrayVar(&varFiles, "var-file", nil, "Load variable values from an HCL document. Repeatable; later files override earlier ones on key collision. Mutually exclusive with --set.")`.
 
-- [ ] **B.2 Enforce mutual exclusion with `--set` (manual check
+- [x] **B.2 Enforce mutual exclusion with `--set` (manual check
       per OQ-2).**
   - File: `cmd/create.go` (modify).
   - Inside `RunE`, after flag parsing:
@@ -289,8 +289,18 @@ exclusion with `--set`, integration with `prompt.CollectVariables`.
     into a shared helper in `cmd/internal/` if duplication grows
     annoying, but inline duplication is fine for two call sites.
 
-- [ ] **B.3 Load the vars file(s) and flow values into `create.Run`
+- [x] **B.3 Load the vars file(s) and flow values into `create.Run`
       (per OQ-3 — extend `Opts` rather than stringify).**
+  - Implementation note: rather than load in the CLI and pass the
+    resolved `map[string]cty.Value` in, the CLI passes the raw
+    `--var-file` *paths* via a new `Opts.VarsFiles []string` field
+    and `create.Run` calls `varsfile.Load(opts.VarsFiles,
+    bp.Variables)` itself. This keeps the load co-located with the
+    blueprint parse (which has to happen first to know the declared
+    types) and means the CLI doesn't have to load the blueprint
+    twice. Unknown keys flow back to the CLI on a new
+    `Result.UnknownVarsFileKeys` field, where `cmd/create.go`
+    surfaces them via `ui.Warningf`.
   - File: `internal/create/create.go` (modify).
   - Extend `create.Opts` with a new field:
 
@@ -307,7 +317,7 @@ exclusion with `--set`, integration with `prompt.CollectVariables`.
   - Surface unknown keys via `ui.Warning` styled output
     (`internal/ui/`).
 
-- [ ] **B.4 Integrate with `prompt.CollectVariables`.**
+- [x] **B.4 Integrate with `prompt.CollectVariables`.**
   - File: `internal/prompt/prompt.go` (modify) and/or
     `internal/create/create.go` (modify) — pick whichever layer is
     cleanest given the existing signature.
@@ -331,14 +341,14 @@ exclusion with `--set`, integration with `prompt.CollectVariables`.
     `--defaults`), the existing "missing required variable" error
     path fires unchanged.
 
-- [ ] **B.5 Type-coercion error surfacing.**
+- [x] **B.5 Type-coercion error surfacing.**
   - Errors from `varsfile.Load` must be returned from the command
     `RunE` so Cobra prints them with the standard non-zero exit.
   - Verify the error message renders with file:line:col against a
     real fixture (use the `wrong-type.forge-vars.hcl` fixture from
     Phase A but run end-to-end through `forge create`).
 
-- [ ] **B.6 Integration tests.**
+- [x] **B.6 Integration tests.**
   - File: `cmd/create_test.go` (modify or new — confirm naming
     convention via `cmd/` listing).
   - Test cases:
@@ -361,14 +371,19 @@ exclusion with `--set`, integration with `prompt.CollectVariables`.
       `--defaults` mode the existing "missing required variable"
       error path fires.
 
-- [ ] **B.7 Add the testdata fixtures for the integration tests.**
+- [x] **B.7 Add the testdata fixtures for the integration tests.**
+  - Integration tests use `t.TempDir()` + inline strings rather
+    than a `cmd/testdata/varsfile/` corpus — the fixtures are
+    small enough to read inline at the test site, and using
+    TempDir keeps them hermetic without an extra directory to
+    maintain.
   - Files under `testdata/hcl-registry/` (use the existing
     `hcl-registry/go/api/` blueprint or add a small dedicated
     blueprint for vars-file tests).
   - Files under `cmd/testdata/varsfile/` (proposed; verify with
     convention used by existing tests).
 
-- [ ] **B.8 Run `make ci`.**
+- [x] **B.8 Run `make ci`.**
 
 #### Success Criteria
 

--- a/docs/impl/0008-variable-input-via-vars-file.md
+++ b/docs/impl/0008-variable-input-via-vars-file.md
@@ -140,13 +140,13 @@ yet.
 
 #### Tasks
 
-- [ ] **A.1 Create the package directory and stub file.**
+- [x] **A.1 Create the package directory and stub file.**
   - File: `internal/varsfile/varsfile.go` (new).
   - Package comment summarising responsibility: "parse one or more
     `.forge-vars.hcl` files into a `map[string]cty.Value` keyed by
     variable name, scoped to a blueprint's declared variables."
 
-- [ ] **A.2 Define the public API.**
+- [x] **A.2 Define the public API.**
   - File: `internal/varsfile/varsfile.go` (modify).
   - Exported entry point (proposed signature):
 
@@ -166,7 +166,7 @@ yet.
   - The exported function is the *only* entry point — internal
     helpers (parse, merge, coerce) stay unexported.
 
-- [ ] **A.3 Implement per-file parsing.**
+- [x] **A.3 Implement per-file parsing.**
   - Internal helper: `parseFile(path string) (hcl.Attributes, hcl.Diagnostics)`.
   - **Reject paths that don't end in `.hcl`** with a clear error
     before opening the file (per OQ-8). Message: "vars file 'X':
@@ -180,7 +180,7 @@ yet.
     attribute assignments only, not blocks; got block 'X' at
     file:line:col."
 
-- [ ] **A.4 Implement composition (multiple files).**
+- [x] **A.4 Implement composition (multiple files).**
   - Internal helper: `compose(files []hcl.Attributes) hcl.Attributes`.
   - Walks files left-to-right; later attributes overwrite earlier
     on key collision. Preserves the source `hcl.Attribute` (with
@@ -188,7 +188,7 @@ yet.
     coercion errors point at the file that actually supplied the
     value.
 
-- [ ] **A.5 Implement type coercion against declared types.**
+- [x] **A.5 Implement type coercion against declared types.**
   - Internal helper: `coerce(attrs hcl.Attributes, vars []config.Variable) (map[string]cty.Value, []string, error)`.
   - For each declared variable in `vars`, if the attribute is
     present:
@@ -207,7 +207,7 @@ yet.
   - Variables absent from the file: leave unset (callers fall
     through to prompt / default).
 
-- [ ] **A.6 Hermetic test fixtures.**
+- [x] **A.6 Hermetic test fixtures.**
   - File: `internal/varsfile/testdata/basic.forge-vars.hcl` (new).
   - File: `internal/varsfile/testdata/override.forge-vars.hcl` (new).
   - File: `internal/varsfile/testdata/wrong-type.forge-vars.hcl` (new).
@@ -218,7 +218,7 @@ yet.
   - File: `internal/varsfile/testdata/bad-extension.vars` (new) — covers OQ-8 rejection (correct content, wrong extension).
   - Each fixture is minimal — single-purpose for one test case.
 
-- [ ] **A.7 Unit tests.**
+- [x] **A.7 Unit tests.**
   - File: `internal/varsfile/varsfile_test.go` (new).
   - Test cases (table-driven where structure allows):
     - `Load` happy path: single file, three scalar vars, declared
@@ -242,7 +242,8 @@ yet.
     - Empty file: returns empty map, no error.
   - Use `testify` assertions per CLAUDE.md.
 
-- [ ] **A.8 Run `make lint` and `make fmt`.**
+- [x] **A.8 Run `make lint` and `make fmt`.**
+  - Result: coverage 97.1% (target >=90%); 0 lint issues.
 
 #### Success Criteria
 

--- a/docs/impl/0008-variable-input-via-vars-file.md
+++ b/docs/impl/0008-variable-input-via-vars-file.md
@@ -412,18 +412,18 @@ default behaviour stays "lockfile is the source of truth."
 
 #### Tasks
 
-- [ ] **C.1 Add the `--var-file` flag to `forge sync`.**
+- [x] **C.1 Add the `--var-file` flag to `forge sync`.**
   - File: `cmd/sync.go` (modify).
   - StringArrayVar registration mirroring create.go.
 
-- [ ] **C.2 Enforce mutual exclusion with `--set` on sync.**
+- [x] **C.2 Enforce mutual exclusion with `--set` on sync.**
   - `forge sync` does not currently have a `--set` flag. Decision:
     do not add `--set` to sync as part of this IMPL (out of scope
     — sync stays lockfile-driven by default). The mutual-exclusion
     check collapses to "no work needed" here; if sync ever gains
     `--set`, that future IMPL adds the matching check.
 
-- [ ] **C.3 Enforce `--force` requirement for `--var-file` on sync
+- [x] **C.3 Enforce `--force` requirement for `--var-file` on sync
       (per OQ-4).**
   - File: `cmd/sync.go` (modify).
   - Inside `RunE`, after flag parsing:
@@ -440,7 +440,7 @@ default behaviour stays "lockfile is the source of truth."
   - This makes the lockfile rewrite explicit and prevents
     accidental drift between the lockfile and project state.
 
-- [ ] **C.4 Load vars-file and merge with lockfile.**
+- [x] **C.4 Load vars-file and merge with lockfile.**
   - File: `cmd/sync.go` (modify) and `internal/sync/` as needed.
   - When `--var-file --force` is set, call
     `varsfile.Load(varFiles, bp.Variables)`, then overlay the
@@ -453,7 +453,7 @@ default behaviour stays "lockfile is the source of truth."
   - Type-coercion errors abort the sync before any files are
     touched.
 
-- [ ] **C.5 Integration tests for sync.**
+- [x] **C.5 Integration tests for sync.**
   - File: `cmd/sync_test.go` (modify).
   - Tests:
     - Sync with no `--var-file` → unchanged behaviour (regression
@@ -470,7 +470,7 @@ default behaviour stays "lockfile is the source of truth."
     - Sync with `--var-file FILE --force` and a type-mismatch in
       the vars file → coercion error; lockfile unchanged.
 
-- [ ] **C.6 Run `make ci`.**
+- [x] **C.6 Run `make ci`.**
 
 #### Success Criteria
 

--- a/docs/impl/0008-variable-input-via-vars-file.md
+++ b/docs/impl/0008-variable-input-via-vars-file.md
@@ -493,12 +493,12 @@ actionable (DESIGN-0005-aligned), rather than Cobra's generic
 
 #### Tasks
 
-- [ ] **D.1 Register the `--var-file` flag on `forge check`.**
+- [x] **D.1 Register the `--var-file` flag on `forge check`.**
   - File: `cmd/check.go` (modify).
   - StringArrayVar registration so the flag is *recognised*; help
     text explicitly notes the flag is rejected on check.
 
-- [ ] **D.2 Reject the flag with a clear error.**
+- [x] **D.2 Reject the flag with a clear error.**
   - File: `cmd/check.go` (modify).
   - Inside `RunE`, after flag parsing:
 
@@ -519,7 +519,7 @@ actionable (DESIGN-0005-aligned), rather than Cobra's generic
     supports `--dry-run` today — verify before finalising the
     message. If not, drop that sub-clause.)
 
-- [ ] **D.3 Integration tests for check.**
+- [x] **D.3 Integration tests for check.**
   - File: `cmd/check_test.go` (modify).
   - Tests:
     - `forge check` (no `--var-file`) → unchanged behaviour
@@ -528,7 +528,7 @@ actionable (DESIGN-0005-aligned), rather than Cobra's generic
       rejection message; exit code non-zero; no drift report
       printed.
 
-- [ ] **D.4 Run `make ci`.**
+- [x] **D.4 Run `make ci`.**
 
 #### Success Criteria
 

--- a/docs/release-notes/v0.6.0-vars-file.md
+++ b/docs/release-notes/v0.6.0-vars-file.md
@@ -90,9 +90,9 @@ pipelines, and supports the same scalar types declared in
   value can't be coerced into the declared type errors out before
   any files are written or the lockfile is touched. The error
   message includes the file:line:col of the offending entry.
-- **`sync --var-file --force --dry-run` is the supported preview
-  workflow.** Combine `--dry-run` to see what would change without
-  rewriting the lockfile or any project files.
+- **`--dry-run` is the supported preview hook** — combine it with
+  `--var-file --force` on `forge sync` to see what would change
+  without rewriting the lockfile or any project files.
 
 ## Upgrading
 
@@ -107,6 +107,9 @@ heavily-parameterised blueprint invocations to clean up long
 ## Before you cut
 
 - [ ] Run `make ci` locally — green.
+- [ ] Run `mkdocs build` (or equivalent) to confirm the new release
+      notes file and the MIGRATION.md `#variable-input-preferred-pattern-v06`
+      anchor resolve.
 - [ ] Verify `forge create … --var-file` against the canonical
       downstream registry
       (`github.com/donaldgifford/forge-registry`) produces a

--- a/docs/release-notes/v0.6.0-vars-file.md
+++ b/docs/release-notes/v0.6.0-vars-file.md
@@ -1,0 +1,129 @@
+# Release notes — v0.6.0 `--var-file` variable input
+
+**Status:** Drafted alongside IMPL-0008. To be shipped as forge
+v0.6.0 once the downstream forge-registry verification
+(IMPL-0008 E.5 follow-up) is filed and `make ci` passes on `main`.
+**Semver:** minor bump per IMPL-0008's release-line decision —
+pre-1.0 minors are the right channel for an additive feature. No
+breaking changes; existing `--set` users keep working unchanged.
+
+---
+
+## What's new
+
+`forge create` and `forge sync` now accept a `--var-file PATH` flag
+that loads variable values from one or more HCL documents. This is
+the preferred input pattern for any non-trivial set of inputs (more
+than three or four `--set` flags is the rough threshold).
+
+```hcl
+# my-svc.forge-vars.hcl
+project_name = "mockta-staging"
+go_module    = "github.com/example/mockta"
+replicas     = 3
+tags         = ["beta", "staging"]
+```
+
+```sh
+forge create go/api --var-file ./my-svc.forge-vars.hcl
+```
+
+The file is plain HCL, plays nicely with version control and CI/CD
+pipelines, and supports the same scalar types declared in
+`blueprint.hcl` (string / number / bool / list / map).
+
+## Rules of engagement
+
+- **Repeatable.** `--var-file a.hcl --var-file b.hcl` composes
+  left-to-right; later files win on key collision.
+- **Mutually exclusive with `--set` on a single invocation.** Pick
+  one input source per run. The CLI rejects the combination with an
+  actionable error.
+- **Strict `.hcl` extension on the path** (IMPL-0008 OQ-8). Forge
+  will not load a file whose path does not end in `.hcl`. This
+  closes the door on accidental loading of unrelated files and
+  makes the input contract obvious.
+- **Process substitution (`<(...)`) is not supported.** The
+  documented escape hatch for inline overrides is the *tempfile
+  pattern*:
+
+  ```sh
+  cat > /tmp/override.forge-vars.hcl <<EOF
+  project_name = "mockta-staging"
+  EOF
+  forge create go/api \
+    --var-file ./base.forge-vars.hcl \
+    --var-file /tmp/override.forge-vars.hcl
+  ```
+
+## Per-command semantics
+
+| Command | Behaviour |
+|--------|-----------|
+| `forge create` | Loads vars file(s) and flows the resolved values into the variable resolution chain (vars-file → `--set` (forbidden in combination) → prompts → defaults). Type-coercion errors abort before any files are touched. Unknown keys surface as a warning. |
+| `forge sync` | Overlays vars-file values onto the lockfile-derived variable map, re-renders affected templates, and **rewrites the lockfile** with the new resolved values. **Requires `--force`** because the lockfile rewrite is a deliberate side effect (IMPL-0008 OQ-4). |
+| `forge check` | **Rejects `--var-file` with an actionable error** (IMPL-0008 OQ-5). `forge check` is drift-detection and reads variables from the lockfile only. Use `forge sync --var-file FILE --force --dry-run` to preview drift against alternative values. |
+
+## What didn't change
+
+- **Lockfile shape.** The `.forge-lock.hcl` schema is unchanged.
+  Vars files are an additional *input path* into the same
+  resolution flow that already terminates in
+  `lockfile.ToCtyValues`. The lockfile records the *resolved*
+  values regardless of input source; it does **not** record the
+  vars-file path used (per DESIGN-0005 OQ-3).
+- **`--set` is not deprecated.** Both flags remain first-class.
+  Use whichever fits the invocation.
+- **`blueprint.hcl` schema.** No new declarations needed in
+  `blueprint.hcl`; vars files reference the existing
+  `variable "name" { type = ... default = ... }` entries.
+
+## Behaviour worth knowing
+
+- **Unknown keys are a warning, not an error.** A vars-file key
+  that isn't declared in `blueprint.hcl` produces a CLI warning
+  (`--var-file declared values for variable(s) not in this
+  blueprint: stray_key`) and is silently dropped. This keeps
+  shared base files reusable across blueprints with slightly
+  different schemas.
+- **Type-coercion errors abort cleanly.** A vars-file entry whose
+  value can't be coerced into the declared type errors out before
+  any files are written or the lockfile is touched. The error
+  message includes the file:line:col of the offending entry.
+- **`sync --var-file --force --dry-run` is the supported preview
+  workflow.** Combine `--dry-run` to see what would change without
+  rewriting the lockfile or any project files.
+
+## Upgrading
+
+No action required. v0.6.0 is fully backwards-compatible with v0.5.x
+projects, lockfiles, and blueprints. Existing `forge create --set …`
+and `forge sync` invocations continue to behave exactly as before.
+
+Optional: introduce a `.forge-vars.hcl` file alongside your most
+heavily-parameterised blueprint invocations to clean up long
+`--set` chains.
+
+## Before you cut
+
+- [ ] Run `make ci` locally — green.
+- [ ] Verify `forge create … --var-file` against the canonical
+      downstream registry
+      (`github.com/donaldgifford/forge-registry`) produces a
+      `.forge-lock.hcl` whose `variables` block matches the
+      vars-file contents.
+- [ ] Verify `forge sync … --var-file FILE` without `--force`
+      rejects cleanly with the documented message.
+- [ ] Verify `forge check --var-file FILE` rejects with the
+      pointer at `forge sync … --dry-run`.
+- [ ] File the forge-registry follow-up (IMPL-0008 E.5) to update
+      blueprint READMEs with `.forge-vars.hcl` examples.
+- [ ] Tag and push: `git tag v0.6.0 && git push --tags`. The
+      goreleaser workflow takes it from there.
+
+## References
+
+- [DESIGN-0005 — Variable input via vars file](../design/0005-variable-input-via-vars-file.md) — the contract.
+- [IMPL-0008 — Variable input via vars file](../impl/0008-variable-input-via-vars-file.md) — the implementation plan.
+- [docs/MIGRATION.md § Variable input: preferred pattern](../MIGRATION.md#variable-input-preferred-pattern-v06) — user-facing guidance.
+- [v0.5.0 release notes](v0.5.0-hcl-lockfile.md) — prior format-line release for context.

--- a/internal/create/create.go
+++ b/internal/create/create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/donaldgifford/forge/internal/prompt"
 	"github.com/donaldgifford/forge/internal/registry"
 	tmpl "github.com/donaldgifford/forge/internal/template"
+	"github.com/donaldgifford/forge/internal/varsfile"
 )
 
 // Opts holds the options for the create command.
@@ -26,8 +27,16 @@ type Opts struct {
 	// OutputDir is the target directory. If empty, derived from project_name variable.
 	OutputDir string
 
-	// Overrides are --set key=value pairs from the CLI.
+	// Overrides are --set key=value pairs from the CLI. Mutually
+	// exclusive with VarsFileValues at the CLI layer.
 	Overrides map[string]string
+
+	// VarsFiles is the ordered list of `--var-file` paths supplied at
+	// the CLI (IMPL-0008). create.Run loads and merges them after the
+	// blueprint is parsed, so the declared variable types are known
+	// for type coercion. Mutually exclusive with Overrides at the CLI
+	// layer; both can be empty (the no-CLI-input case).
+	VarsFiles []string
 
 	// UseDefaults skips interactive prompts and uses default values.
 	UseDefaults bool
@@ -66,6 +75,13 @@ type Result struct {
 	OutputDir    string
 	FilesCreated int
 	Blueprint    string
+
+	// UnknownVarsFileKeys lists keys declared in any --var-file input
+	// that don't correspond to a declared blueprint variable. The CLI
+	// surfaces these as a warning (per IMPL-0008 OQ-7 — no
+	// --strict-vars flag in v1). Empty when no --var-file paths were
+	// supplied or every key matched a declared variable.
+	UnknownVarsFileKeys []string
 }
 
 // Run executes the create workflow.
@@ -85,8 +101,18 @@ func Run(opts *Opts) (*Result, error) {
 
 	logger.Debug("loaded blueprint", "name", bp.Name, "version", bp.Version)
 
+	// 5b. Load --var-file inputs (IMPL-0008). Vars-file values
+	//     short-circuit prompts the same way --set overrides do.
+	//     Mutually exclusive with Overrides at the CLI layer.
+	varsFileValues, unknownKeys, err := varsfile.Load(opts.VarsFiles, bp.Variables)
+	if err != nil {
+		return nil, fmt.Errorf("loading vars file: %w", err)
+	}
+
 	// 6. Collect variables.
-	vars, err := prompt.CollectVariables(bp.Variables, opts.Overrides, opts.UseDefaults, opts.PromptFn)
+	vars, err := prompt.CollectVariables(
+		bp.Variables, opts.Overrides, varsFileValues, opts.UseDefaults, opts.PromptFn,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("collecting variables: %w", err)
 	}
@@ -141,9 +167,10 @@ func Run(opts *Opts) (*Result, error) {
 	logger.Info("project created", "dir", outputDir, "files", filesCreated)
 
 	return &Result{
-		OutputDir:    outputDir,
-		FilesCreated: filesCreated,
-		Blueprint:    bp.Name,
+		OutputDir:           outputDir,
+		FilesCreated:        filesCreated,
+		Blueprint:           bp.Name,
+		UnknownVarsFileKeys: unknownKeys,
 	}, nil
 }
 

--- a/internal/create/varsfile_integration_test.go
+++ b/internal/create/varsfile_integration_test.go
@@ -1,0 +1,207 @@
+package create_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/donaldgifford/forge/internal/create"
+	"github.com/donaldgifford/forge/internal/lockfile"
+)
+
+// writeVarsFile is a tiny helper used by the vars-file integration
+// tests. Centralising it avoids repeating the byte-cast + permission
+// boilerplate across six tests.
+func writeVarsFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+// newVarsFileOpts is a minimal Opts shape for vars-file tests: no
+// overrides (the vars file supplies all values), --defaults so prompts
+// stay disabled, and the standard test registry.
+func newVarsFileOpts(t *testing.T, outputDir string, varsFiles ...string) *create.Opts {
+	t.Helper()
+
+	return &create.Opts{
+		BlueprintRef: "go/api",
+		OutputDir:    outputDir,
+		RegistryDir:  absTestRegistryDir(t),
+		VarsFiles:    varsFiles,
+		UseDefaults:  true,
+		NoHooks:      true,
+		ForceCreate:  false,
+		ForgeVersion: "test-vars-file",
+	}
+}
+
+// TestCreate_VarsFile_BasicScaffold verifies that a single --var-file
+// produces the same scaffold a CLI invocation with equivalent --set
+// flags would. The lockfile is the cleanest assertion target: it
+// preserves the resolved variable map.
+func TestCreate_VarsFile_BasicScaffold(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	varsPath := writeVarsFile(t, tmp, "vars.forge-vars.hcl", `
+project_name = "my-api"
+go_module    = "github.com/example/my-api"
+use_grpc     = true
+license      = "MIT"
+`)
+
+	outputDir := filepath.Join(tmp, "my-api")
+	opts := newVarsFileOpts(t, outputDir, varsPath)
+
+	result, err := create.Run(opts)
+	require.NoError(t, err)
+	assert.Empty(t, result.UnknownVarsFileKeys)
+
+	lock, err := lockfile.LoadLockfile(outputDir)
+	require.NoError(t, err)
+	assert.Equal(t, "my-api", lock.Variables["project_name"])
+	assert.Equal(t, "github.com/example/my-api", lock.Variables["go_module"])
+	assert.Equal(t, true, lock.Variables["use_grpc"])
+	assert.Equal(t, "MIT", lock.Variables["license"])
+}
+
+// TestCreate_VarsFile_LastWins verifies left-to-right override
+// semantics across multiple --var-file inputs. The override file
+// changes use_grpc; everything else inherits from the base.
+func TestCreate_VarsFile_LastWins(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	base := writeVarsFile(t, tmp, "base.forge-vars.hcl", `
+project_name = "my-api"
+go_module    = "github.com/example/my-api"
+use_grpc     = false
+license      = "MIT"
+`)
+	override := writeVarsFile(t, tmp, "override.forge-vars.hcl", `
+use_grpc = true
+`)
+
+	outputDir := filepath.Join(tmp, "my-api")
+	opts := newVarsFileOpts(t, outputDir, base, override)
+
+	_, err := create.Run(opts)
+	require.NoError(t, err)
+
+	lock, err := lockfile.LoadLockfile(outputDir)
+	require.NoError(t, err)
+	assert.Equal(t, true, lock.Variables["use_grpc"])
+	assert.Equal(t, "my-api", lock.Variables["project_name"])
+}
+
+// TestCreate_VarsFile_UnknownKeys_NonFatal verifies that an unknown
+// key surfaces via Result.UnknownVarsFileKeys but does not fail the
+// scaffold (IMPL-0008 OQ-7).
+func TestCreate_VarsFile_UnknownKeys_NonFatal(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	varsPath := writeVarsFile(t, tmp, "extra.forge-vars.hcl", `
+project_name      = "my-api"
+go_module         = "github.com/example/my-api"
+license           = "MIT"
+this_key_does_not_exist = "ignored"
+`)
+
+	outputDir := filepath.Join(tmp, "my-api")
+	opts := newVarsFileOpts(t, outputDir, varsPath)
+
+	result, err := create.Run(opts)
+	require.NoError(t, err)
+
+	assert.Contains(t, result.UnknownVarsFileKeys, "this_key_does_not_exist")
+
+	// The known keys still landed in the lockfile.
+	lock, err := lockfile.LoadLockfile(outputDir)
+	require.NoError(t, err)
+	assert.Equal(t, "my-api", lock.Variables["project_name"])
+
+	// And the unknown key is NOT persisted.
+	_, hasUnknown := lock.Variables["this_key_does_not_exist"]
+	assert.False(t, hasUnknown)
+}
+
+// TestCreate_VarsFile_TypeMismatch_AbortsScaffold verifies that a
+// vars-file value that can't coerce to the declared type fails the
+// run before any files are written.
+func TestCreate_VarsFile_TypeMismatch_AbortsScaffold(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	varsPath := writeVarsFile(t, tmp, "bad.forge-vars.hcl", `
+project_name = "my-api"
+go_module    = "github.com/example/my-api"
+use_grpc     = "not-a-bool"
+license      = "MIT"
+`)
+
+	outputDir := filepath.Join(tmp, "my-api")
+	opts := newVarsFileOpts(t, outputDir, varsPath)
+
+	_, err := create.Run(opts)
+	require.Error(t, err)
+
+	msg := err.Error()
+	assert.Contains(t, msg, "bad.forge-vars.hcl")
+	assert.Contains(t, msg, "use_grpc")
+
+	// Scaffold should not have happened.
+	_, statErr := os.Stat(outputDir)
+	assert.True(t, os.IsNotExist(statErr), "output directory should not be created on type-coercion failure")
+}
+
+// TestCreate_VarsFile_PartialFile_FallsThroughToDefaults verifies that
+// a vars file that omits some variables doesn't force those into the
+// "missing required" error path when defaults exist. The blueprint's
+// default for go_module references project_name, so the rendered
+// default must still work.
+func TestCreate_VarsFile_PartialFile_FallsThroughToDefaults(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	varsPath := writeVarsFile(t, tmp, "partial.forge-vars.hcl", `
+project_name = "my-api"
+license      = "MIT"
+`)
+
+	outputDir := filepath.Join(tmp, "my-api")
+	opts := newVarsFileOpts(t, outputDir, varsPath)
+
+	_, err := create.Run(opts)
+	require.NoError(t, err)
+
+	lock, err := lockfile.LoadLockfile(outputDir)
+	require.NoError(t, err)
+	// project_name from vars file; go_module from default template
+	// `github.com/example/${project_name}`.
+	assert.Equal(t, "my-api", lock.Variables["project_name"])
+	assert.Equal(t, "github.com/example/my-api", lock.Variables["go_module"])
+}
+
+// TestCreate_VarsFile_BadExtension_Rejected verifies the OQ-8 rule:
+// only `.hcl` extensions are accepted on --var-file paths.
+func TestCreate_VarsFile_BadExtension_Rejected(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	varsPath := writeVarsFile(t, tmp, "vars.txt", `project_name = "my-api"`)
+
+	outputDir := filepath.Join(tmp, "my-api")
+	opts := newVarsFileOpts(t, outputDir, varsPath)
+
+	_, err := create.Run(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ".hcl")
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -20,16 +20,30 @@ var defaultRenderer = tmpl.NewRenderer()
 // PromptFn is a callback for interactive variable input.
 type PromptFn func(v *config.Variable, current map[string]any) (string, error)
 
-// CollectVariables resolves all blueprint variables using overrides, defaults, and
-// optional interactive prompting. Variables are processed in declaration order so
-// that later defaults can reference earlier variable values.
+// CollectVariables resolves all blueprint variables using vars-file inputs,
+// --set overrides, defaults, and optional interactive prompting. Variables
+// are processed in declaration order so that later defaults can reference
+// earlier variable values.
 //
-// If useDefaults is true, all variables use their default values without prompting.
-// The promptFn callback is called for variables that need interactive input; pass nil
-// to skip interactive prompting (useful in tests or CI with --defaults).
+// Resolution order per declared variable:
+//
+//  1. varsFileValues (IMPL-0008): a value loaded from `--var-file` short-circuits
+//     the override / default / prompt chain. These are already coerced to the
+//     declared blueprint type by varsfile.Load.
+//  2. overrides: a `--set key=value` value coerced and validated against the
+//     declared blueprint type.
+//  3. default: the blueprint-supplied default, rendered through the HCL2
+//     renderer so it can reference earlier variable values.
+//  4. prompt: the interactive callback (skipped when useDefaults is true or
+//     promptFn is nil).
+//
+// varsFileValues and overrides are mutually exclusive at the CLI layer;
+// CollectVariables accepts both for flexibility (tests may stub either
+// path) but does not enforce that exclusion itself.
 func CollectVariables(
 	vars []config.Variable,
 	overrides map[string]string,
+	varsFileValues map[string]cty.Value,
 	useDefaults bool,
 	promptFn PromptFn,
 ) (map[string]any, error) {
@@ -38,7 +52,7 @@ func CollectVariables(
 	for i := range vars {
 		v := &vars[i]
 
-		val, err := resolveVariable(v, overrides, result, useDefaults, promptFn)
+		val, err := resolveVariable(v, overrides, varsFileValues, result, useDefaults, promptFn)
 		if err != nil {
 			return nil, err
 		}
@@ -49,15 +63,22 @@ func CollectVariables(
 	return result, nil
 }
 
-// resolveVariable resolves a single variable value through the override → default → prompt chain.
+// resolveVariable resolves a single variable value through the
+// vars-file → override → default → prompt chain.
 func resolveVariable(
 	v *config.Variable,
 	overrides map[string]string,
+	varsFileValues map[string]cty.Value,
 	current map[string]any,
 	useDefaults bool,
 	promptFn PromptFn,
 ) (any, error) {
-	// Check for CLI override first.
+	// 1. Vars-file value short-circuits everything else (IMPL-0008).
+	if val, ok := varsFileValues[v.Name]; ok {
+		return resolveFromVarsFile(val, v)
+	}
+
+	// 2. --set override.
 	if raw, ok := overrides[v.Name]; ok {
 		return resolveFromOverride(raw, v)
 	}
@@ -75,6 +96,54 @@ func resolveVariable(
 
 	// Interactive prompt.
 	return resolveFromPrompt(v, current, defaultVal, promptFn)
+}
+
+// resolveFromVarsFile converts a cty.Value supplied via --var-file into
+// the `any` form used throughout the variable resolution chain. The
+// value is already coerced to the declared blueprint type by
+// varsfile.Load, so this is a straightforward Go-type unwrap with
+// validation applied against the string form.
+func resolveFromVarsFile(val cty.Value, v *config.Variable) (any, error) {
+	if !val.IsKnown() || val.IsNull() {
+		if v.Required {
+			return nil, fmt.Errorf("vars-file value for %q is null but variable is required", v.Name)
+		}
+
+		return zeroValue(v.Type), nil
+	}
+
+	goVal := ctyToGo(val)
+
+	// Apply the same regex-based validation overrides go through; the
+	// validate regex is defined against the string serialisation.
+	if err := validateValue(fmt.Sprintf("%v", goVal), v); err != nil {
+		return nil, fmt.Errorf("vars-file value for %q failed validation: %w", v.Name, err)
+	}
+
+	return goVal, nil
+}
+
+// ctyToGo converts a cty.Value to the Go `any` shape this package uses
+// for the resolution chain. Mirrors lockfile.FromCtyValues for the
+// primitive cty types; vars files are scalar-only in IMPL-0008 so
+// nested/structural types don't appear here.
+func ctyToGo(val cty.Value) any {
+	switch val.Type() {
+	case cty.String:
+		return val.AsString()
+	case cty.Bool:
+		return val.True()
+	case cty.Number:
+		if i, acc := val.AsBigFloat().Int64(); acc == 0 {
+			return i
+		}
+
+		f, _ := val.AsBigFloat().Float64()
+
+		return f
+	default:
+		return val.GoString()
+	}
 }
 
 // resolveFromOverride validates and coerces an override value.

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -23,7 +23,7 @@ func TestCollectVariables_Overrides(t *testing.T) {
 		"use_grpc":     "true",
 	}
 
-	result, err := prompt.CollectVariables(vars, overrides, false, nil)
+	result, err := prompt.CollectVariables(vars, overrides, nil, false, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "my-api", result["project_name"])
@@ -39,7 +39,7 @@ func TestCollectVariables_Defaults(t *testing.T) {
 		{Name: "verbose", Type: "bool", Default: "false"},
 	}
 
-	result, err := prompt.CollectVariables(vars, nil, true, nil)
+	result, err := prompt.CollectVariables(vars, nil, nil, true, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "default-project", result["project_name"])
@@ -55,7 +55,7 @@ func TestCollectVariables_TemplatedDefault(t *testing.T) {
 		{Name: "go_module", Type: "string", Default: "github.com/example/${project_name}"},
 	}
 
-	result, err := prompt.CollectVariables(vars, nil, true, nil)
+	result, err := prompt.CollectVariables(vars, nil, nil, true, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "github.com/example/my-api", result["go_module"])
@@ -68,7 +68,7 @@ func TestCollectVariables_RequiredNoDefault(t *testing.T) {
 		{Name: "project_name", Type: "string", Required: true},
 	}
 
-	_, err := prompt.CollectVariables(vars, nil, true, nil)
+	_, err := prompt.CollectVariables(vars, nil, nil, true, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "required but has no default")
 }
@@ -84,7 +84,7 @@ func TestCollectVariables_OverrideValidation(t *testing.T) {
 		"project_name": "INVALID",
 	}
 
-	_, err := prompt.CollectVariables(vars, overrides, false, nil)
+	_, err := prompt.CollectVariables(vars, overrides, nil, false, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed validation")
 }
@@ -100,7 +100,7 @@ func TestCollectVariables_InvalidBoolOverride(t *testing.T) {
 		"flag": "not-a-bool",
 	}
 
-	_, err := prompt.CollectVariables(vars, overrides, false, nil)
+	_, err := prompt.CollectVariables(vars, overrides, nil, false, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid override")
 }
@@ -116,7 +116,7 @@ func TestCollectVariables_InvalidIntOverride(t *testing.T) {
 		"port": "not-a-number",
 	}
 
-	_, err := prompt.CollectVariables(vars, overrides, false, nil)
+	_, err := prompt.CollectVariables(vars, overrides, nil, false, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid override")
 }
@@ -140,7 +140,7 @@ func TestCollectVariables_PromptFn(t *testing.T) {
 		}
 	}
 
-	result, err := prompt.CollectVariables(vars, nil, false, promptFn)
+	result, err := prompt.CollectVariables(vars, nil, nil, false, promptFn)
 	require.NoError(t, err)
 
 	assert.Equal(t, "prompted-project", result["project_name"])
@@ -159,7 +159,7 @@ func TestCollectVariables_PromptFnUsesDefault(t *testing.T) {
 		return "", nil
 	}
 
-	result, err := prompt.CollectVariables(vars, nil, false, promptFn)
+	result, err := prompt.CollectVariables(vars, nil, nil, false, promptFn)
 	require.NoError(t, err)
 
 	assert.Equal(t, "default-name", result["name"])
@@ -179,7 +179,7 @@ func TestCollectVariables_OverrideTakesPrecedence(t *testing.T) {
 		return "prompted-name", nil
 	}
 
-	result, err := prompt.CollectVariables(vars, overrides, false, promptFn)
+	result, err := prompt.CollectVariables(vars, overrides, nil, false, promptFn)
 	require.NoError(t, err)
 
 	assert.Equal(t, "override-name", result["name"])
@@ -192,7 +192,7 @@ func TestCollectVariables_ChoiceType(t *testing.T) {
 		{Name: "license", Type: "choice", Choices: []string{"MIT", "Apache-2.0", "none"}, Default: "Apache-2.0"},
 	}
 
-	result, err := prompt.CollectVariables(vars, nil, true, nil)
+	result, err := prompt.CollectVariables(vars, nil, nil, true, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "Apache-2.0", result["license"])
@@ -207,7 +207,7 @@ func TestCollectVariables_ZeroValues(t *testing.T) {
 		{Name: "count", Type: "int"},
 	}
 
-	result, err := prompt.CollectVariables(vars, nil, true, nil)
+	result, err := prompt.CollectVariables(vars, nil, nil, true, nil)
 	require.NoError(t, err)
 
 	assert.Empty(t, result["name"])

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3,6 +3,7 @@ package sync
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/donaldgifford/forge/internal/config"
 	"github.com/donaldgifford/forge/internal/lockfile"
 	tmpl "github.com/donaldgifford/forge/internal/template"
+	"github.com/donaldgifford/forge/internal/varsfile"
 )
 
 // Opts configures the sync operation.
@@ -25,10 +27,17 @@ type Opts struct {
 	BaseDir string
 	// DryRun prints what would change without writing.
 	DryRun bool
-	// Force skips confirmation prompts.
+	// Force skips confirmation prompts. When VarsFiles is non-empty,
+	// the CLI requires Force=true before reaching this point (per
+	// IMPL-0008 OQ-4) — sync trusts its caller to have enforced that.
 	Force bool
 	// FileFilter limits sync to a single file path.
 	FileFilter string
+	// VarsFiles is the ordered list of `--var-file` paths supplied at
+	// the CLI (IMPL-0008). When non-empty, sync.Run overlays the
+	// loaded values onto the lockfile-derived variable map and
+	// rewrites the lockfile with the merged result.
+	VarsFiles []string
 }
 
 // Result holds the outcome of a sync operation.
@@ -37,6 +46,11 @@ type Result struct {
 	Skipped       []string
 	Conflicts     []string
 	ConflictFiles []ConflictFile
+
+	// UnknownVarsFileKeys lists keys declared in any --var-file input
+	// that don't correspond to a declared blueprint variable. The CLI
+	// surfaces these as a warning (IMPL-0008 OQ-7).
+	UnknownVarsFileKeys []string
 }
 
 // Run executes the sync workflow.
@@ -61,6 +75,13 @@ func Run(opts *Opts) (*Result, error) {
 	ctyVars, err := lockfile.ToCtyValues(lock.Variables, bpVars)
 	if err != nil {
 		return nil, fmt.Errorf("converting lockfile variables to cty: %w", err)
+	}
+
+	// IMPL-0008 Phase C: overlay --var-file values onto the
+	// lockfile-derived map. The CLI enforces the --force requirement
+	// before reaching here; sync just needs to merge and persist.
+	if err := applyVarsFileOverlay(opts.VarsFiles, bpVars, ctyVars, result); err != nil {
+		return nil, err
 	}
 
 	// Sync defaults.
@@ -89,19 +110,69 @@ func Run(opts *Opts) (*Result, error) {
 		}
 	}
 
-	// Update lockfile if not dry-run.
-	if !opts.DryRun && len(result.Updated) > 0 {
-		lock.LastSynced = time.Now().UTC()
-
-		// Recompute content hashes for synced files.
-		updateFileHashes(projectDir, lock)
-
-		if err := lockfile.WriteHCL(lockPath, lock); err != nil {
-			return nil, fmt.Errorf("updating lockfile: %w", err)
-		}
+	if err := persistLockfile(opts, lockPath, lock, ctyVars, result); err != nil {
+		return nil, err
 	}
 
 	return result, nil
+}
+
+// persistLockfile rewrites the lockfile to record updated timestamps,
+// content hashes, and (when --var-file was used) the overlaid
+// variable values. No-op when DryRun is set or there's nothing to
+// record. Vars-file overlays force a rewrite even when no managed
+// files changed — the new variable values themselves are persistent
+// state worth recording.
+func persistLockfile(
+	opts *Opts,
+	lockPath string,
+	lock *lockfile.Lockfile,
+	ctyVars map[string]cty.Value,
+	result *Result,
+) error {
+	varsFileChanged := len(opts.VarsFiles) > 0
+	if opts.DryRun || (len(result.Updated) == 0 && !varsFileChanged) {
+		return nil
+	}
+
+	lock.LastSynced = time.Now().UTC()
+
+	updateFileHashes(opts.ProjectDir, lock)
+
+	if varsFileChanged {
+		lock.Variables = lockfile.FromCtyValues(ctyVars)
+	}
+
+	if err := lockfile.WriteHCL(lockPath, lock); err != nil {
+		return fmt.Errorf("updating lockfile: %w", err)
+	}
+
+	return nil
+}
+
+// applyVarsFileOverlay loads any --var-file inputs and merges the
+// resolved values into ctyVars in place. Unknown keys land on
+// result.UnknownVarsFileKeys for the caller to surface. Returns nil
+// (no-op) when no vars-file paths were supplied.
+func applyVarsFileOverlay(
+	paths []string,
+	bpVars []config.Variable,
+	ctyVars map[string]cty.Value,
+	result *Result,
+) error {
+	if len(paths) == 0 {
+		return nil
+	}
+
+	overlay, unknown, err := varsfile.Load(paths, bpVars)
+	if err != nil {
+		return fmt.Errorf("loading vars file: %w", err)
+	}
+
+	maps.Copy(ctyVars, overlay)
+	result.UnknownVarsFileKeys = unknown
+
+	return nil
 }
 
 func syncDefault(
@@ -123,7 +194,9 @@ func syncDefault(
 		return err
 	}
 
-	localPath := filepath.Join(opts.ProjectDir, d.Path)
+	// The lockfile stores the source path (e.g. "greet.txt.tmpl"), but
+	// the rendered output lives at the stripped name ("greet.txt").
+	localPath := filepath.Join(opts.ProjectDir, tmpl.StripTemplateExtension(d.Path))
 
 	return applyOverwrite(localPath, sourceContent, opts.DryRun, result)
 }

--- a/internal/sync/varsfile_integration_test.go
+++ b/internal/sync/varsfile_integration_test.go
@@ -1,0 +1,249 @@
+package sync_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/donaldgifford/forge/internal/lockfile"
+	forgesync "github.com/donaldgifford/forge/internal/sync"
+)
+
+// writeVarsFile is a small helper used across the sync vars-file tests.
+func writeVarsFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+// setupVarsFileSyncTest builds a minimal project + registry pair: the
+// registry has a `_defaults/greet.txt.tmpl` template that renders
+// `Hello, ${name}!`. The project's initial lockfile records the
+// pre-sync values (name = "world") and the matching default entry, so
+// `sync` can re-render after a --var-file overlay.
+func setupVarsFileSyncTest(t *testing.T) (projectDir, registryDir string) {
+	t.Helper()
+
+	projectDir = t.TempDir()
+	registryDir = t.TempDir()
+
+	// Registry: blueprint.hcl declares `name` as a string, and
+	// _defaults/ ships a templated greeting.
+	bpDir := filepath.Join(registryDir, "demo", "bp")
+	require.NoError(t, os.MkdirAll(bpDir, 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(bpDir, "blueprint.hcl"),
+		[]byte(`name = "demo-bp"
+
+variable "name" {
+  type    = "string"
+  default = "world"
+}
+`),
+		0o600,
+	))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(registryDir, "_defaults"), 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(registryDir, "_defaults", "greet.txt.tmpl"),
+		[]byte("Hello, ${name}!\n"),
+		0o600,
+	))
+
+	// Project: lockfile already records the pre-sync state.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, "greet.txt"),
+		[]byte("Hello, world!\n"),
+		0o600,
+	))
+
+	lock := &lockfile.Lockfile{
+		Blueprint: lockfile.BlueprintRef{
+			Name: "demo-bp",
+			Path: "demo/bp",
+		},
+		Variables: map[string]any{"name": "world"},
+		Defaults: []lockfile.DefaultEntry{
+			{Path: "greet.txt.tmpl", Source: "registry-default", Strategy: "overwrite"},
+		},
+	}
+	require.NoError(t, lockfile.WriteHCL(
+		filepath.Join(projectDir, lockfile.HCLFileName), lock,
+	))
+
+	return projectDir, registryDir
+}
+
+// TestSync_VarsFile_OverridesLockfileValue is the headline happy-path
+// test: --var-file overlays a new value for `name`, sync re-renders
+// the template, and the lockfile records the new value.
+func TestSync_VarsFile_OverridesLockfileValue(t *testing.T) {
+	t.Parallel()
+
+	projectDir, registryDir := setupVarsFileSyncTest(t)
+	tmp := t.TempDir()
+	varsPath := writeVarsFile(t, tmp, "v.forge-vars.hcl", `name = "forge"`+"\n")
+
+	opts := &forgesync.Opts{
+		ProjectDir:  projectDir,
+		RegistryDir: registryDir,
+		VarsFiles:   []string{varsPath},
+	}
+
+	result, err := forgesync.Run(opts)
+	require.NoError(t, err)
+	assert.Empty(t, result.UnknownVarsFileKeys)
+
+	// Rendered file updated.
+	content, err := os.ReadFile(filepath.Join(projectDir, "greet.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, forge!\n", string(content))
+
+	// Lockfile records the new value.
+	lock, err := lockfile.LoadLockfile(projectDir)
+	require.NoError(t, err)
+	assert.Equal(t, "forge", lock.Variables["name"])
+}
+
+// TestSync_VarsFile_DryRun_DoesNotWrite verifies that --dry-run
+// suppresses both the rendered output and the lockfile rewrite even
+// when a --var-file is supplied.
+func TestSync_VarsFile_DryRun_DoesNotWrite(t *testing.T) {
+	t.Parallel()
+
+	projectDir, registryDir := setupVarsFileSyncTest(t)
+	tmp := t.TempDir()
+	varsPath := writeVarsFile(t, tmp, "v.forge-vars.hcl", `name = "forge"`+"\n")
+
+	opts := &forgesync.Opts{
+		ProjectDir:  projectDir,
+		RegistryDir: registryDir,
+		VarsFiles:   []string{varsPath},
+		DryRun:      true,
+	}
+
+	_, err := forgesync.Run(opts)
+	require.NoError(t, err)
+
+	// File unchanged.
+	content, err := os.ReadFile(filepath.Join(projectDir, "greet.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, world!\n", string(content))
+
+	// Lockfile still records the original value.
+	lock, err := lockfile.LoadLockfile(projectDir)
+	require.NoError(t, err)
+	assert.Equal(t, "world", lock.Variables["name"])
+}
+
+// TestSync_VarsFile_UnknownKey_Warned verifies that a --var-file with
+// a key not declared in the blueprint surfaces a warning on
+// Result.UnknownVarsFileKeys but does not error the sync.
+func TestSync_VarsFile_UnknownKey_Warned(t *testing.T) {
+	t.Parallel()
+
+	projectDir, registryDir := setupVarsFileSyncTest(t)
+	tmp := t.TempDir()
+	varsPath := writeVarsFile(t, tmp, "extra.forge-vars.hcl",
+		"name = \"forge\"\nstray_key = \"ignored\"\n")
+
+	opts := &forgesync.Opts{
+		ProjectDir:  projectDir,
+		RegistryDir: registryDir,
+		VarsFiles:   []string{varsPath},
+	}
+
+	result, err := forgesync.Run(opts)
+	require.NoError(t, err)
+	assert.Contains(t, result.UnknownVarsFileKeys, "stray_key")
+
+	// Unknown key NOT persisted to the lockfile.
+	lock, err := lockfile.LoadLockfile(projectDir)
+	require.NoError(t, err)
+	_, hasStray := lock.Variables["stray_key"]
+	assert.False(t, hasStray)
+}
+
+// TestSync_VarsFile_TypeMismatch_Aborts verifies that a coercion
+// failure short-circuits the sync before any files are written or
+// the lockfile is rewritten.
+func TestSync_VarsFile_TypeMismatch_Aborts(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	registryDir := t.TempDir()
+
+	// Blueprint declares `count` as int.
+	bpDir := filepath.Join(registryDir, "demo", "bp")
+	require.NoError(t, os.MkdirAll(bpDir, 0o750))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(bpDir, "blueprint.hcl"),
+		[]byte(`name = "demo-bp"
+
+variable "count" {
+  type    = "int"
+  default = "1"
+}
+`),
+		0o600,
+	))
+
+	lock := &lockfile.Lockfile{
+		Blueprint: lockfile.BlueprintRef{
+			Name: "demo-bp",
+			Path: "demo/bp",
+		},
+		Variables: map[string]any{"count": int64(1)},
+	}
+	lockPath := filepath.Join(projectDir, lockfile.HCLFileName)
+	require.NoError(t, lockfile.WriteHCL(lockPath, lock))
+
+	preSync, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+
+	tmp := t.TempDir()
+	varsPath := writeVarsFile(t, tmp, "bad.forge-vars.hcl", `count = "not-a-number"`+"\n")
+
+	_, err = forgesync.Run(&forgesync.Opts{
+		ProjectDir:  projectDir,
+		RegistryDir: registryDir,
+		VarsFiles:   []string{varsPath},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "count")
+
+	// Lockfile unchanged.
+	postSync, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, preSync, postSync)
+}
+
+// TestSync_NoVarsFile_LockfileUnchangedWhenIdle is a regression guard:
+// without --var-file and without registry drift, sync must NOT touch
+// the lockfile (timestamps included). This keeps git diffs quiet for
+// the common "ran sync, nothing changed" case.
+func TestSync_NoVarsFile_LockfileUnchangedWhenIdle(t *testing.T) {
+	t.Parallel()
+
+	projectDir, registryDir := setupVarsFileSyncTest(t)
+	lockPath := filepath.Join(projectDir, lockfile.HCLFileName)
+
+	preSync, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+
+	_, err = forgesync.Run(&forgesync.Opts{
+		ProjectDir:  projectDir,
+		RegistryDir: registryDir,
+	})
+	require.NoError(t, err)
+
+	postSync, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.Equal(t, preSync, postSync, "lockfile should be byte-identical when nothing changed")
+}

--- a/internal/varsfile/testdata/bad-extension.vars
+++ b/internal/varsfile/testdata/bad-extension.vars
@@ -1,0 +1,1 @@
+project_name = "my-api"

--- a/internal/varsfile/testdata/basic.forge-vars.hcl
+++ b/internal/varsfile/testdata/basic.forge-vars.hcl
@@ -1,0 +1,3 @@
+project_name = "my-api"
+use_grpc     = true
+port         = 8080

--- a/internal/varsfile/testdata/malformed.forge-vars.hcl
+++ b/internal/varsfile/testdata/malformed.forge-vars.hcl
@@ -1,0 +1,1 @@
+project_name = "missing close quote

--- a/internal/varsfile/testdata/override.forge-vars.hcl
+++ b/internal/varsfile/testdata/override.forge-vars.hcl
@@ -1,0 +1,2 @@
+project_name = "my-api-staging"
+port         = 9090

--- a/internal/varsfile/testdata/unknown-keys.forge-vars.hcl
+++ b/internal/varsfile/testdata/unknown-keys.forge-vars.hcl
@@ -1,0 +1,3 @@
+project_name = "my-api"
+extra_one    = "ignored-1"
+extra_two    = 42

--- a/internal/varsfile/testdata/with-blocks.forge-vars.hcl
+++ b/internal/varsfile/testdata/with-blocks.forge-vars.hcl
@@ -1,0 +1,5 @@
+project_name = "my-api"
+
+variable "use_grpc" {
+  value = true
+}

--- a/internal/varsfile/testdata/with-function-call.forge-vars.hcl
+++ b/internal/varsfile/testdata/with-function-call.forge-vars.hcl
@@ -1,0 +1,1 @@
+project_name = upper("my-api")

--- a/internal/varsfile/testdata/wrong-type.forge-vars.hcl
+++ b/internal/varsfile/testdata/wrong-type.forge-vars.hcl
@@ -1,0 +1,2 @@
+project_name = "my-api"
+use_grpc     = "not a bool"

--- a/internal/varsfile/varsfile.go
+++ b/internal/varsfile/varsfile.go
@@ -1,0 +1,255 @@
+// Package varsfile parses one or more `.forge-vars.hcl` files into a
+// map[string]cty.Value keyed by variable name, scoped to a blueprint's
+// declared variables.
+//
+// The package implements DESIGN-0005 — Variable input via vars file
+// (IMPL-0008). Vars files are attribute-only HCL documents:
+//
+//	# example.forge-vars.hcl
+//	project_name = "my-api"
+//	use_grpc     = true
+//	port         = 8080
+//
+// They compose left-to-right (later files override earlier ones on key
+// collision), enforce strict literal values (no function calls, no
+// references — see IMPL-0008 OQ-1), and require the `.hcl` file
+// extension (IMPL-0008 OQ-8). Attribute values are coerced against the
+// declared variable types from the target blueprint.
+//
+// The package exposes a single entry point, Load. Parsing, composition,
+// and coercion stay internal so callers cannot reach into half-resolved
+// state.
+package varsfile
+
+import (
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+
+	"github.com/donaldgifford/forge/internal/config"
+)
+
+// requiredExt is the only file extension accepted for vars files
+// (per IMPL-0008 OQ-8).
+const requiredExt = ".hcl"
+
+// Load parses every path in order and merges the resulting attribute
+// maps left-to-right: later files override earlier files on key
+// collision. Values are coerced against the declared variable types in
+// vars. Unknown keys (present in a file but not declared in vars) are
+// returned in the unknown slice for the caller to surface as a warning.
+//
+// Returns an error if any file has the wrong extension, fails to read,
+// fails to parse, contains a block, contains a non-literal expression
+// (function call, traversal, …), or fails type coercion. The error
+// includes file:line:col when the underlying HCL diagnostic carries
+// that information.
+func Load(paths []string, vars []config.Variable) (resolved map[string]cty.Value, unknown []string, err error) {
+	if len(paths) == 0 {
+		return map[string]cty.Value{}, nil, nil
+	}
+
+	parser := hclparse.NewParser()
+
+	merged := make(map[string]*hcl.Attribute)
+
+	for _, path := range paths {
+		attrs, parseErr := parseFile(parser, path)
+		if parseErr != nil {
+			return nil, nil, parseErr
+		}
+
+		maps.Copy(merged, attrs)
+	}
+
+	resolved, unknown, err = coerce(merged, vars)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return resolved, unknown, nil
+}
+
+// parseFile reads path, parses it as HCL, and returns the
+// top-level attribute set. It rejects:
+//
+//   - paths without a .hcl extension (IMPL-0008 OQ-8);
+//   - parse errors from hclparse;
+//   - top-level blocks (vars files are attribute-only).
+//
+// The returned map is keyed by attribute name, value is the parsed
+// hcl.Attribute (so callers see the source range when reporting
+// downstream errors).
+func parseFile(parser *hclparse.Parser, path string) (map[string]*hcl.Attribute, error) {
+	if ext := filepath.Ext(path); ext != requiredExt {
+		return nil, fmt.Errorf(
+			"vars file %q: only %s extensions are supported; got %q",
+			path, requiredExt, ext,
+		)
+	}
+
+	src, err := os.ReadFile(path) //nolint:gosec // path comes from user-supplied --var-file inputs, matching the existing config loader's posture
+	if err != nil {
+		return nil, fmt.Errorf("reading vars file %s: %w", path, err)
+	}
+
+	file, diags := parser.ParseHCL(src, path)
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("parsing vars file %s: %s", path, diags.Error())
+	}
+
+	// Reject any top-level blocks before extracting attributes —
+	// JustAttributes only complains via a diagnostic, not a hard
+	// error, so an explicit block scan gives a cleaner message.
+	if blockErr := rejectBlocks(file.Body, path); blockErr != nil {
+		return nil, blockErr
+	}
+
+	attrs, attrDiags := file.Body.JustAttributes()
+	if attrDiags.HasErrors() {
+		return nil, fmt.Errorf("vars file %s: %s", path, attrDiags.Error())
+	}
+
+	return attrs, nil
+}
+
+// rejectBlocks walks body looking for top-level blocks and surfaces
+// a clear error if any are present. Vars files are attribute-only by
+// design (DESIGN-0005 File Format). Concrete `*hclsyntax.Body` is
+// what `hclparse` produces; reaching into it directly gives a
+// cleaner error than letting JustAttributes' generic "Blocks are not
+// allowed here" diagnostic leak out.
+func rejectBlocks(body hcl.Body, path string) error {
+	syntaxBody, ok := body.(*hclsyntax.Body)
+	if !ok {
+		return nil
+	}
+
+	for _, block := range syntaxBody.Blocks {
+		return fmt.Errorf(
+			"vars file %s: contains block %q at %s:%d,%d — vars files accept attribute assignments only, not blocks",
+			path,
+			block.Type,
+			path,
+			block.DefRange().Start.Line,
+			block.DefRange().Start.Column,
+		)
+	}
+
+	return nil
+}
+
+// coerce evaluates each attribute against the declared variable type
+// in vars and returns the resolved cty.Value map plus a list of
+// unknown keys (attributes in the file that don't match any declared
+// variable). Evaluation uses an empty EvalContext: no functions, no
+// variables, no traversals are accessible — only literal values pass
+// (IMPL-0008 OQ-1).
+func coerce(attrs map[string]*hcl.Attribute, vars []config.Variable) (map[string]cty.Value, []string, error) {
+	declared := make(map[string]config.Variable, len(vars))
+	for i := range vars {
+		declared[vars[i].Name] = vars[i]
+	}
+
+	resolved := make(map[string]cty.Value, len(attrs))
+
+	var unknown []string
+
+	for name, attr := range attrs {
+		v, ok := declared[name]
+		if !ok {
+			unknown = append(unknown, name)
+
+			continue
+		}
+
+		val, err := evalLiteral(attr)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		coerced, err := coerceToDeclared(val, v.Type, attr)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		resolved[name] = coerced
+	}
+
+	return resolved, unknown, nil
+}
+
+// evalLiteral evaluates attr.Expr in an empty EvalContext, rejecting
+// any expression that depends on variables, functions, or traversals.
+// Returns a literal cty.Value or a file:line:col-located error.
+func evalLiteral(attr *hcl.Attribute) (cty.Value, error) {
+	if traversals := attr.Expr.Variables(); len(traversals) > 0 {
+		t := traversals[0]
+		rng := t.SourceRange()
+
+		return cty.NilVal, fmt.Errorf(
+			"vars file %s:%d,%d: variable %q only accepts literal values; references and traversals are not supported",
+			rng.Filename, rng.Start.Line, rng.Start.Column, attr.Name,
+		)
+	}
+
+	val, diags := attr.Expr.Value(&hcl.EvalContext{})
+	if diags.HasErrors() {
+		// Empty EvalContext intentionally rejects function calls;
+		// surface the first diagnostic with its source location for
+		// the caller.
+		rng := attr.Expr.Range()
+
+		return cty.NilVal, fmt.Errorf(
+			"vars file %s:%d,%d: variable %q only accepts literal values: %s",
+			rng.Filename, rng.Start.Line, rng.Start.Column, attr.Name, diags.Error(),
+		)
+	}
+
+	return val, nil
+}
+
+// coerceToDeclared converts the literal val to the cty.Value that
+// matches the declared blueprint variable type. cty.Convert already
+// handles the common string→number and string→bool coercions a
+// vars-file author would write (e.g. `port = "42"` against a
+// declared int), so the fallback layer that lockfile.ToCtyValues
+// keeps for YAML scalars isn't needed here. Errors carry the
+// vars-file source location of the attribute that supplied val.
+func coerceToDeclared(val cty.Value, declaredType string, attr *hcl.Attribute) (cty.Value, error) {
+	target := ctyTypeForDeclared(declaredType)
+
+	converted, err := convert.Convert(val, target)
+	if err == nil {
+		return converted, nil
+	}
+
+	rng := attr.Expr.Range()
+
+	return cty.NilVal, fmt.Errorf(
+		"vars file %s:%d,%d: variable %q expects %s, got %s: %w",
+		rng.Filename, rng.Start.Line, rng.Start.Column,
+		attr.Name, declaredType, val.Type().FriendlyName(), err,
+	)
+}
+
+// ctyTypeForDeclared maps a blueprint variable type tag to its
+// cty.Type. Unknown tags fall through to cty.String — matches the
+// loose-by-default posture of lockfile.ToCtyValues.
+func ctyTypeForDeclared(declaredType string) cty.Type {
+	switch declaredType {
+	case "bool":
+		return cty.Bool
+	case "int":
+		return cty.Number
+	default:
+		return cty.String
+	}
+}

--- a/internal/varsfile/varsfile_test.go
+++ b/internal/varsfile/varsfile_test.go
@@ -1,0 +1,254 @@
+package varsfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/donaldgifford/forge/internal/config"
+	"github.com/donaldgifford/forge/internal/varsfile"
+)
+
+// declaredVars is the standard variable declaration set used across
+// table-driven tests. project_name is required string, use_grpc is
+// bool with default false, port is int with default 8080.
+func declaredVars() []config.Variable {
+	return []config.Variable{
+		{Name: "project_name", Type: "string", Required: true},
+		{Name: "use_grpc", Type: "bool", Default: "false"},
+		{Name: "port", Type: "int", Default: "8080"},
+	}
+}
+
+func TestLoad_HappyPath_ScalarTypes(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("testdata", "basic.forge-vars.hcl")
+
+	resolved, unknown, err := varsfile.Load([]string{path}, declaredVars())
+	require.NoError(t, err)
+	assert.Empty(t, unknown)
+
+	assert.Equal(t, cty.StringVal("my-api"), resolved["project_name"])
+	assert.Equal(t, cty.True, resolved["use_grpc"])
+
+	port, _ := resolved["port"].AsBigFloat().Int64()
+	assert.Equal(t, int64(8080), port)
+}
+
+func TestLoad_Composition_LastWins(t *testing.T) {
+	t.Parallel()
+
+	base := filepath.Join("testdata", "basic.forge-vars.hcl")
+	override := filepath.Join("testdata", "override.forge-vars.hcl")
+
+	resolved, unknown, err := varsfile.Load([]string{base, override}, declaredVars())
+	require.NoError(t, err)
+	assert.Empty(t, unknown)
+
+	// project_name overridden.
+	assert.Equal(t, cty.StringVal("my-api-staging"), resolved["project_name"])
+
+	// port overridden.
+	port, _ := resolved["port"].AsBigFloat().Int64()
+	assert.Equal(t, int64(9090), port)
+
+	// use_grpc preserved from base.
+	assert.Equal(t, cty.True, resolved["use_grpc"])
+}
+
+func TestLoad_Composition_ThreeFiles(t *testing.T) {
+	t.Parallel()
+
+	// Synthesize a third file that overrides project_name again.
+	third := filepath.Join(t.TempDir(), "third.forge-vars.hcl")
+	require.NoError(t, writeFile(third, `project_name = "from-third"`+"\n"))
+
+	resolved, _, err := varsfile.Load([]string{
+		filepath.Join("testdata", "basic.forge-vars.hcl"),
+		filepath.Join("testdata", "override.forge-vars.hcl"),
+		third,
+	}, declaredVars())
+	require.NoError(t, err)
+
+	assert.Equal(t, cty.StringVal("from-third"), resolved["project_name"])
+}
+
+func TestLoad_Coercion_StringToInt(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "stringy-int.forge-vars.hcl")
+	require.NoError(t, writeFile(path, `port = "42"`+"\n"))
+
+	resolved, _, err := varsfile.Load([]string{path}, declaredVars())
+	require.NoError(t, err)
+
+	got, _ := resolved["port"].AsBigFloat().Int64()
+	assert.Equal(t, int64(42), got)
+}
+
+func TestLoad_Coercion_TypeMismatch_PointsAtSource(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("testdata", "wrong-type.forge-vars.hcl")
+
+	_, _, err := varsfile.Load([]string{path}, declaredVars())
+	require.Error(t, err)
+
+	msg := err.Error()
+	assert.Contains(t, msg, "wrong-type.forge-vars.hcl")
+	assert.Contains(t, msg, "use_grpc")
+	assert.Contains(t, msg, "bool")
+}
+
+func TestLoad_UnknownKeys_ReturnedNotErrored(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("testdata", "unknown-keys.forge-vars.hcl")
+
+	resolved, unknown, err := varsfile.Load([]string{path}, declaredVars())
+	require.NoError(t, err)
+
+	sort.Strings(unknown)
+	assert.Equal(t, []string{"extra_one", "extra_two"}, unknown)
+
+	// project_name still resolved.
+	assert.Equal(t, cty.StringVal("my-api"), resolved["project_name"])
+
+	// Unknown keys are not silently added to the resolved map.
+	_, hasExtra := resolved["extra_one"]
+	assert.False(t, hasExtra)
+}
+
+func TestLoad_Malformed_PointsAtFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("testdata", "malformed.forge-vars.hcl")
+
+	_, _, err := varsfile.Load([]string{path}, declaredVars())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "malformed.forge-vars.hcl")
+}
+
+func TestLoad_Blocks_Rejected(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("testdata", "with-blocks.forge-vars.hcl")
+
+	_, _, err := varsfile.Load([]string{path}, declaredVars())
+	require.Error(t, err)
+
+	msg := err.Error()
+	assert.Contains(t, msg, "with-blocks.forge-vars.hcl")
+	assert.Contains(t, msg, "attribute assignments only, not blocks")
+}
+
+func TestLoad_FunctionCall_Rejected(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("testdata", "with-function-call.forge-vars.hcl")
+
+	_, _, err := varsfile.Load([]string{path}, declaredVars())
+	require.Error(t, err)
+
+	msg := err.Error()
+	assert.Contains(t, msg, "with-function-call.forge-vars.hcl")
+	assert.Contains(t, msg, "literal values")
+}
+
+func TestLoad_BadExtension_Rejected(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("testdata", "bad-extension.vars")
+
+	_, _, err := varsfile.Load([]string{path}, declaredVars())
+	require.Error(t, err)
+
+	msg := err.Error()
+	assert.Contains(t, msg, "bad-extension.vars")
+	assert.Contains(t, msg, ".hcl")
+}
+
+func TestLoad_MissingFile_WrapsError(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := varsfile.Load([]string{"/nonexistent/path.forge-vars.hcl"}, declaredVars())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading vars file")
+}
+
+func TestLoad_EmptyFile_NoError(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("testdata", "empty.forge-vars.hcl")
+
+	resolved, unknown, err := varsfile.Load([]string{path}, declaredVars())
+	require.NoError(t, err)
+	assert.Empty(t, resolved)
+	assert.Empty(t, unknown)
+}
+
+func TestLoad_NoPaths_ReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	resolved, unknown, err := varsfile.Load(nil, declaredVars())
+	require.NoError(t, err)
+	assert.NotNil(t, resolved)
+	assert.Empty(t, resolved)
+	assert.Empty(t, unknown)
+}
+
+func TestLoad_Coercion_StringToBool(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "stringy-bool.forge-vars.hcl")
+	require.NoError(t, writeFile(path, `use_grpc = "true"`+"\n"))
+
+	resolved, _, err := varsfile.Load([]string{path}, declaredVars())
+	require.NoError(t, err)
+	assert.Equal(t, cty.True, resolved["use_grpc"])
+}
+
+func TestLoad_TraversalReference_Rejected(t *testing.T) {
+	t.Parallel()
+
+	// `var.foo` is a traversal — vars files must not reach outside
+	// themselves (IMPL-0008 OQ-1, strict literals).
+	path := filepath.Join(t.TempDir(), "traversal.forge-vars.hcl")
+	require.NoError(t, writeFile(path, `project_name = var.foo`+"\n"))
+
+	_, _, err := varsfile.Load([]string{path}, declaredVars())
+	require.Error(t, err)
+
+	msg := err.Error()
+	assert.Contains(t, msg, "traversal.forge-vars.hcl")
+	assert.Contains(t, msg, "literal values")
+}
+
+func TestLoad_OverrideSourceLocation_PointsAtWinningFile(t *testing.T) {
+	t.Parallel()
+
+	// Two files where the second one supplies a type-mismatched
+	// value — the error must point at file two, not file one.
+	good := filepath.Join(t.TempDir(), "good.forge-vars.hcl")
+	require.NoError(t, writeFile(good, `use_grpc = true`+"\n"))
+
+	bad := filepath.Join(t.TempDir(), "bad.forge-vars.hcl")
+	require.NoError(t, writeFile(bad, `use_grpc = "not a bool"`+"\n"))
+
+	_, _, err := varsfile.Load([]string{good, bad}, declaredVars())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad.forge-vars.hcl")
+}
+
+// writeFile is a tiny helper so the tests stay readable; using
+// os.WriteFile inline would push every test over the package's line
+// budget.
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o600)
+}


### PR DESCRIPTION
## Summary

- Adds `--var-file PATH` to `forge create` and `forge sync` for loading variable values from `.forge-vars.hcl` files (repeatable, last-wins composition, mutually exclusive with `--set` on a single invocation).
- `forge sync --var-file` requires `--force` (rewrites the lockfile with the resolved values); `forge check --var-file` is rejected with an actionable error.
- Ships the new `internal/varsfile` package (single exported `Load`), full docs (MIGRATION.md, DESIGN-0005, README, CLAUDE.md), and v0.6.0 release notes.

Implements [IMPL-0008](docs/impl/0008-variable-input-via-vars-file.md) (DESIGN-0005). Phases A → E all green; IMPL doc status is now Accepted.

## Phase-by-phase commits

| Commit | Phase | What |
|--------|-------|------|
| `ab2730c` | A | New `internal/varsfile` package — strict `.hcl` extension, attributes-only, no functions/traversals, last-wins composition, type coercion via `cty/convert`. 97% coverage. |
| `0686041` | B | `--var-file` on `forge create`; mutual exclusion with `--set` via `requireSingleVarSource`. |
| `e6480d9` | C | `--var-file` on `forge sync`; `--force` requirement via `requireForceForVarFile`; lockfile rewrite gated so idle syncs stay byte-identical. Also fixes a latent bug in `syncDefault` (rendered output was being written to `foo.txt.tmpl` instead of stripping to `foo.txt`). |
| `7211e3a` | D | `--var-file` registered on `forge check` only to emit an actionable rejection pointing at `forge sync --var-file FILE --force --dry-run`. |
| `4baa234` | E | MIGRATION.md, DESIGN-0005, README, CLAUDE.md, v0.6.0 release notes. |
| `474dcbb` | E.6 | docz-reviewer pass: fixed DESIGN-0005 dead reference, clarified Goals re `forge check`, collapsed redundant `--dry-run` guidance in release notes, added `mkdocs build` to "Before you cut" checklist. |

## Notable design decisions

- **Strict `.hcl` extension on the input path** (IMPL-0008 OQ-8). Process substitution (`<(...)`) is not supported; the documented escape hatch is the tempfile pattern.
- **Mutual exclusion via manual check, not Cobra's `MarkFlagsMutuallyExclusive`** (IMPL-0008 OQ-2) — DESIGN-0005's error wording is more actionable than Cobra's generic phrasing.
- **`forge sync --var-file` requires `--force`** (IMPL-0008 OQ-4) — the lockfile rewrite is a deliberate side effect.
- **Unknown keys are a warning, not an error.** Keeps shared base files reusable across blueprints with slightly different schemas.
- **No lockfile schema change.** Vars files are an additional input path into the existing resolution flow that already terminates in `lockfile.ToCtyValues`.

## Test plan

- [x] `make ci` green
- [x] `internal/varsfile` unit tests (14 cases incl. happy path, composition, coercion, unknown keys, malformed HCL, block/function/traversal rejection, bad extension, missing/empty files)
- [x] `internal/create` integration tests (6 cases incl. basic scaffold, last-wins, unknown-key warning, type-mismatch abort, partial-file fall-through, bad extension)
- [x] `internal/sync` integration tests (5 cases incl. override+re-render, dry-run preservation, unknown-key warning, type-mismatch abort with lockfile preservation, idle-sync byte-identical regression)
- [x] `cmd/create_test.go` and `cmd/check_test.go` for the mutual-exclusion and rejection helpers
- [ ] Manual smoke test against `github.com/donaldgifford/forge-registry` (IMPL-0008 E.5 follow-up — to be filed when this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)