### PR TITLE
docs: add canonical HCL reference + auto-gen INV

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ forge cache clean
 - [DESIGN-0003 — Migrate template engine to HCL2](docs/design/0003-migrate-template-engine-to-hcl2.md) -- Engine swap rationale
 - [DESIGN-0004 — Unify config file format after HCL2 cutover](docs/design/0004-unify-config-file-format-after-hcl2-cutover.md) -- Config-format unification
 - [ADR-0001 — Use HCL2 as the template engine](docs/adr/0001-use-hcl2-as-the-template-engine.md) -- Decision record
+- [docs/REFERENCE.md](docs/REFERENCE.md) -- Canonical HCL reference for `blueprint.hcl`, `registry.hcl`, `.forge-lock.hcl`, `.forge-vars.hcl`
 - [docs/MIGRATION.md](docs/MIGRATION.md) -- v0.2.x → v0.5.x migration guides
 - [RFC-0001 — Forge: Project Scaffolding CLI](docs/rfc/0001-forge-project-scaffolding-cli.md) -- High-level proposal and architecture
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1,0 +1,495 @@
+# Forge HCL reference
+
+This is the canonical reference for the four HCL file formats forge
+reads and writes:
+
+| File | Authored by | Read by | Section |
+|------|-------------|---------|---------|
+| `blueprint.hcl` | Blueprint author | `forge create`, `forge sync`, `forge check`, `forge info` | [blueprint.hcl](#blueprinthcl) |
+| `registry.hcl` | Registry maintainer | `forge list`, `forge search`, `forge create` (for resolution) | [registry.hcl](#registryhcl) |
+| `.forge-lock.hcl` | `forge create` / `forge sync` (generated) | `forge sync`, `forge check`, `forge info` | [.forge-lock.hcl](#forge-lockhcl) |
+| `.forge-vars.hcl` | Project consumer | `forge create --var-file`, `forge sync --var-file` | [.forge-vars.hcl](#forge-varshcl) |
+
+> **Source of truth.** This document is hand-maintained but every
+> claim is traceable to a Go source file. If the implementation and
+> this doc diverge, the implementation wins — file a bug. See
+> [INV-0002](investigation/0002-auto-generate-hcl-reference-doc.md) for an
+> evaluation of auto-generation approaches we considered.
+
+> **Format gating.** HCL is the only accepted on-disk format from
+> v0.5+ for all four files. Bare `.yaml` inputs are rejected at load
+> time with a rescaffold-or-pin pointer (see
+> [docs/MIGRATION.md](MIGRATION.md) and
+> [ADR-0002](adr/0002-forge-does-not-ship-in-tool-migrators.md)).
+
+<!--toc:start-->
+- [blueprint.hcl](#blueprinthcl)
+  - [Top-level attributes](#top-level-attributes)
+  - [variable](#variable)
+  - [condition](#condition)
+  - [defaults](#defaults)
+  - [hooks](#hooks)
+  - [sync](#sync)
+  - [rename](#rename)
+- [registry.hcl](#registryhcl)
+- [.forge-lock.hcl](#forge-lockhcl)
+- [.forge-vars.hcl](#forge-varshcl)
+- [Variable types](#variable-types)
+- [Sync strategies](#sync-strategies)
+- [CLI flags affecting config](#cli-flags-affecting-config)
+- [Source-of-truth files](#source-of-truth-files)
+<!--toc:end-->
+
+---
+
+## blueprint.hcl
+
+The blueprint config file lives at the root of a blueprint directory
+inside the registry (e.g. `go/api/blueprint.hcl`). It declares the
+blueprint's identity, the variables it prompts for, conditional file
+inclusion rules, post-create hooks, and the managed-file sync
+manifest.
+
+### Top-level attributes
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | **yes** | Blueprint identifier (e.g. `"go-api"`). Surfaced by `forge list`. |
+| `description` | string | no | Short human-readable summary. Surfaced by `forge info`. |
+| `version` | string | no | Author-controlled semver. Recorded in the lockfile. |
+| `tags` | list(string) | no | Tag list for `forge search` filtering. |
+
+```hcl
+name        = "go-api"
+description = "Production Go service with metrics, tracing, and Helm chart"
+version     = "1.2.0"
+tags        = ["go", "service", "api"]
+```
+
+### variable
+
+`variable "name" { … }` declares a user-prompted variable. The block
+label becomes the variable name. Repeat the block once per variable.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `type` | string | **yes** | One of [`string`, `bool`, `choice`, `int`](#variable-types). |
+| `description` | string | no | Shown to the user during interactive prompts. |
+| `default` | expression | no | Default value. May be a template (`"${other_var}-api"`) — evaluated after the variables it references are bound. |
+| `required` | bool | no | When `true`, the user cannot accept an empty value. |
+| `choices` | list(string) | conditional | **Required when `type = "choice"`**; the menu options. Ignored for other types. |
+| `validate` | string | no | Regular expression (Go `regexp` syntax) the resolved value must match. Compiled at load time. |
+
+```hcl
+variable "project_name" {
+  type        = "string"
+  description = "Service name; used in module paths and helm release name"
+  required    = true
+  validate    = "^[a-z][a-z0-9-]*$"
+}
+
+variable "go_module" {
+  type    = "string"
+  default = "github.com/example/${project_name}"
+}
+
+variable "use_grpc" {
+  type    = "bool"
+  default = "false"
+}
+
+variable "license" {
+  type    = "choice"
+  choices = ["Apache-2.0", "MIT", "BSD-3-Clause"]
+  default = "Apache-2.0"
+}
+
+variable "port" {
+  type    = "int"
+  default = "8080"
+}
+```
+
+> **Why `default` is stringly-typed.** It is held as raw source text
+> so the prompt renderer can re-evaluate it after other variables are
+> bound (the template `"${project_name}-api"` only resolves once
+> `project_name` is known). Coercion to the declared type happens
+> when the resolved value is read.
+
+### condition
+
+`condition { when = … exclude = […] }` conditionally excludes files
+from the rendered output. Repeat the block once per rule.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `when` | expression | **yes** | HCL2 expression evaluated against the resolved variable set. Excludes apply when this evaluates to `true`. Captured at load time so syntax errors surface with file:line:col. |
+| `exclude` | list(string) | no | Glob patterns (relative to the blueprint root) to exclude when `when` is true. |
+
+```hcl
+condition {
+  when    = use_grpc == false
+  exclude = ["proto/**", "Makefile.grpc"]
+}
+```
+
+### defaults
+
+`defaults { … }` controls inherited `_defaults/` files
+(see [DESIGN-0002](design/0002-registry-layout-and-defaults-inheritance.md)).
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `exclude` | list(string) | no | Relative paths under `_defaults/` to omit from this blueprint. |
+| `override_strategy` | map(string→string) | no | Per-path sync-strategy override. Values must be a valid [sync strategy](#sync-strategies). |
+
+```hcl
+defaults {
+  exclude = [".github/dependabot.yml"]
+  override_strategy = {
+    "Makefile" = "merge"
+  }
+}
+```
+
+### hooks
+
+`hooks { post_create = […] }` configures lifecycle hooks.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `post_create` | list(string) | no | Shell commands run after `forge create` completes. Each command runs through `sh -c` in the project root. Cancellation via the create context propagates. |
+
+```hcl
+hooks {
+  post_create = [
+    "go mod tidy",
+    "make fmt",
+  ]
+}
+```
+
+### sync
+
+`sync { … }` declares the managed-file manifest used by `forge sync`
+and `forge check`.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `ignore` | list(string) | no | Glob patterns excluded from drift detection and sync entirely. |
+
+| Nested block | Required | Description |
+|--------------|----------|-------------|
+| `managed_file "path" { strategy = … }` | conditional | One per managed file. Label is the project-relative path. |
+
+The nested `managed_file` block:
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `strategy` | string | **yes** | One of [`overwrite`, `merge`](#sync-strategies). |
+
+```hcl
+sync {
+  ignore = ["dist/**", "vendor/**"]
+
+  managed_file "Makefile" {
+    strategy = "merge"
+  }
+
+  managed_file ".github/workflows/ci.yml" {
+    strategy = "overwrite"
+  }
+}
+```
+
+### rename
+
+`rename { entry { from = …, to = … } … }` rewrites output paths.
+Children are unlabeled `entry` blocks so both `from` and `to` can
+carry templates (block labels and attribute names reject template
+sequences).
+
+| `entry` attribute | Type | Required | Description |
+|-------------------|------|----------|-------------|
+| `from` | string | **yes** | Source path glob. May contain `${var}` references. |
+| `to` | string | **yes** | Destination path. May contain `${var}` references. |
+
+```hcl
+rename {
+  entry {
+    from = "cmd/app/main.go"
+    to   = "cmd/${project_name}/main.go"
+  }
+}
+```
+
+---
+
+## registry.hcl
+
+The index file at the root of a registry repo. Maintained by
+`forge registry update` after blueprint additions/changes, but
+hand-editable.
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | **yes** | Registry display name. |
+| `description` | string | no | Short summary. |
+
+| Nested block | Required | Description |
+|--------------|----------|-------------|
+| `maintainer { name = …, email = … }` | no | Repeatable. |
+| `defaults { sync_strategy = …, managed = … }` | no | Registry-wide defaults. Distinct from the per-blueprint `defaults` block in `blueprint.hcl`. |
+| `blueprint "name" { … }` | no | Repeatable catalog entry. Label is the blueprint name. |
+
+`defaults`:
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `sync_strategy` | string | no | Default sync strategy applied to inherited `_defaults/` files. One of [`overwrite`, `merge`](#sync-strategies). |
+| `managed` | bool | no | When `true`, registry-wide defaults are treated as managed files for sync. |
+
+`blueprint` catalog entry:
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | **yes** | Relative path from the registry root to the blueprint directory. |
+| `description` | string | no | Short summary. |
+| `version` | string | no | Author-controlled semver (mirrors the value in `blueprint.hcl`). |
+| `tags` | list(string) | no | Tag list for search. |
+| `latest_commit` | string | no | Commit SHA when the catalog entry was last refreshed. Set by `forge registry update`. |
+
+```hcl
+name        = "Example Registry"
+description = "Internal blueprints for the platform team"
+
+maintainer {
+  name  = "Platform Team"
+  email = "platform@example.com"
+}
+
+defaults {
+  sync_strategy = "merge"
+  managed       = true
+}
+
+blueprint "go-api" {
+  path        = "go/api"
+  description = "Production Go service"
+  version     = "1.2.0"
+  tags        = ["go", "service"]
+}
+```
+
+---
+
+## .forge-lock.hcl
+
+The lockfile records the provenance of a scaffolded project and the
+state needed by `forge sync` / `forge check`. It is **generated** by
+`forge create` and **rewritten** by `forge sync`. Do not edit by
+hand — the file carries a `# DO NOT EDIT MANUALLY` header.
+
+A bare `.forge-lock.yaml` (the legacy format) is rejected at load
+time with a rescaffold-or-pin error per
+[ADR-0002](adr/0002-forge-does-not-ship-in-tool-migrators.md).
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `created_at` | string (RFC3339 UTC) | When the project was scaffolded. |
+| `last_synced` | string (RFC3339 UTC) | When `forge sync` last touched the project. Equal to `created_at` on a fresh scaffold. |
+| `forge_version` | string | The forge binary version that wrote this lockfile. |
+
+| Nested block | Description |
+|--------------|-------------|
+| `blueprint { … }` | The source blueprint reference (one per lockfile). |
+| `variables { … }` | The resolved variable map used to render this project. Keys are dynamic. |
+| `default "path" { … }` | Repeatable. One entry per inherited default file. |
+| `managed_file "path" { … }` | Repeatable. One entry per managed file. |
+
+`blueprint`:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `registry_url` | string | Go-getter URL or local path of the registry. |
+| `name` | string | Blueprint name (from `blueprint.hcl`). |
+| `path` | string | Blueprint path within the registry. |
+| `ref` | string | Git ref (branch/tag) at scaffold time. |
+| `commit` | string | Commit SHA at scaffold time. Used as the base in three-way merge during sync. |
+
+`default "path"`:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `source` | string | Which layer the default came from: `registry-default`, `<category>-default`, etc. |
+| `strategy` | string | One of [`overwrite`, `merge`](#sync-strategies). |
+| `hash` | string | `sha256:<hex>` of the rendered file content. Used by `forge check` for drift detection. |
+| `synced_commit` | string | Commit SHA last successfully synced for this file. |
+
+`managed_file "path"`:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `strategy` | string | One of [`overwrite`, `merge`](#sync-strategies). |
+| `hash` | string | `sha256:<hex>` of the file content. Used by `forge check` for drift detection. |
+| `synced_commit` | string | Commit SHA last successfully synced for this file. |
+
+`variables` carries native HCL primitives (string / number / bool /
+list / map) — types are preserved end-to-end from
+`blueprint.hcl`.
+
+```hcl
+# .forge-lock.hcl — DO NOT EDIT MANUALLY
+# Generated by forge. Changes will be overwritten on sync.
+
+blueprint {
+  registry_url = "github.com/example/forge-registry"
+  name         = "go-api"
+  path         = "go/api"
+  ref          = "v1.2.0"
+  commit       = "a3f9c1d"
+}
+
+created_at    = "2026-05-19T10:15:30Z"
+last_synced   = "2026-05-19T10:15:30Z"
+forge_version = "0.6.0"
+
+variables {
+  project_name = "my-api"
+  go_module    = "github.com/example/my-api"
+  use_grpc     = false
+  port         = 8080
+}
+
+default ".editorconfig" {
+  source   = "registry-default"
+  strategy = "overwrite"
+  hash     = "sha256:abc123..."
+}
+
+managed_file "Makefile" {
+  strategy = "merge"
+  hash     = "sha256:def456..."
+}
+```
+
+---
+
+## .forge-vars.hcl
+
+A `.forge-vars.hcl` file supplies variable values to `forge create`
+and `forge sync` via `--var-file`. The format is intentionally
+narrow: **attributes only, literal values only**. No blocks,
+function calls, or traversals. The `.hcl` extension is **required**
+on the path.
+
+See [DESIGN-0005](design/0005-variable-input-via-vars-file.md) for
+the contract and
+[IMPL-0008](impl/0008-variable-input-via-vars-file.md) for the
+implementation details.
+
+```hcl
+# my-svc.forge-vars.hcl
+project_name = "mockta-staging"
+go_module    = "github.com/example/mockta"
+use_grpc     = true
+port         = 8080
+tags         = ["beta", "staging"]
+```
+
+| Rule | Detail |
+|------|--------|
+| File extension | Must be `.hcl`. Process substitution (`<(…)`) fails this check; use the tempfile pattern instead. |
+| Document grammar | Top-level attributes only. Blocks (`foo { … }`) are rejected with a `vars file may not contain blocks` error. |
+| Expression grammar | Values must be literal: strings, numbers, bools, lists, maps. Function calls (`upper("x")`), references (`other_var`), and computed expressions are rejected with a `variable only accepts literal values` error. |
+| Composition | `--var-file` is repeatable; later files override earlier files on key collision. |
+| Type coercion | Values are coerced against the declared blueprint variable type via `cty/convert`. Coercion failures abort before any files are written. |
+| Unknown keys | Keys that are not declared in `blueprint.hcl` surface as a CLI **warning**, not an error, and are silently dropped from the resolved map. |
+| Mutual exclusion | `--var-file` and `--set` cannot both appear on a single invocation. The CLI rejects the combination. |
+| `forge sync` | `--var-file` requires `--force` because it rewrites the lockfile with the new resolved values. |
+| `forge check` | `--var-file` is rejected with an actionable error pointing at `forge sync --var-file FILE --force --dry-run`. |
+
+---
+
+## Variable types
+
+The four types accepted by the `type` attribute of a `variable`
+block. Defined in
+[`internal/config/validate.go`](../internal/config/validate.go):
+
+| Type | Description | Native cty type |
+|------|-------------|-----------------|
+| `string` | Free-text string. Optionally constrained via `validate` regex. | `cty.String` |
+| `bool` | Boolean. Accepts `true`/`false` literals or stringly-typed coercions (e.g. `"true"`). | `cty.Bool` |
+| `choice` | String constrained to one of `choices`. **`choices` is required.** | `cty.String` |
+| `int` | Integer. Stored as `cty.Number` natively; coerced from string vars-file inputs (`port = "8080"` works). | `cty.Number` |
+
+Adding a new type means touching three sites:
+
+1. [`internal/config/validate.go`](../internal/config/validate.go) — `validVariableTypes` map.
+2. [`internal/lockfile/cty.go`](../internal/lockfile/cty.go) — `ToCtyValues` / `FromCtyValues`.
+3. [`internal/varsfile/varsfile.go`](../internal/varsfile/varsfile.go) — `ctyTypeForDeclared`.
+
+---
+
+## Sync strategies
+
+The two strategies accepted by `strategy` attributes on `managed_file`
+blocks and the `override_strategy` map. Defined in
+[`internal/config/validate.go`](../internal/config/validate.go):
+
+| Strategy | Behaviour |
+|----------|-----------|
+| `overwrite` | `forge sync` replaces the local file with the rendered upstream version, no merge attempted. |
+| `merge` | `forge sync` runs a three-way merge using the lockfile's `synced_commit` as the base, the local file as `ours`, and the rendered upstream as `theirs`. Conflicts are reported via `forge sync` exit code and surfaced through `ReportConflicts`. |
+
+---
+
+## CLI flags affecting config
+
+A non-exhaustive list of flags that change how forge reads or writes
+the files above:
+
+| Flag | Commands | Effect |
+|------|----------|--------|
+| `--set key=value` | `create` | Inline variable value. Repeatable. Mutually exclusive with `--var-file`. |
+| `--var-file PATH` | `create`, `sync` | Load variable values from a `.forge-vars.hcl` file. Repeatable. On `sync`, requires `--force`. Rejected on `check`. |
+| `--force` | `create`, `sync` | On `create`: write into a non-empty directory. On `sync`: required when `--var-file` is supplied (acknowledges the lockfile rewrite). |
+| `--registry-dir` | `create`, `sync`, `check` | Override the registry source. Accepts local paths and go-getter URLs (auto-detected). |
+| `--ref` | `sync` | Pin sync against a specific registry version/ref. |
+| `--dry-run` | `sync` | Print what would change without writing. Compose with `--var-file --force` for the preview workflow. |
+| `--file PATH` | `sync` | Sync only a specific file path. |
+
+---
+
+## Source-of-truth files
+
+Every claim in this document maps to one or more of:
+
+| Concern | File |
+|---------|------|
+| Blueprint Go schema | [`internal/config/blueprint.go`](../internal/config/blueprint.go) |
+| Registry Go schema | [`internal/config/registry.go`](../internal/config/registry.go) |
+| Lockfile Go schema | [`internal/lockfile/lock.go`](../internal/lockfile/lock.go) |
+| HCL decode specs (blueprint + registry) | [`internal/config/hcldec_spec.go`](../internal/config/hcldec_spec.go) |
+| Allowed `type` and `strategy` values | [`internal/config/validate.go`](../internal/config/validate.go) |
+| Variable-to-cty type mapping | [`internal/lockfile/cty.go`](../internal/lockfile/cty.go) |
+| Vars-file parser + coercion | [`internal/varsfile/varsfile.go`](../internal/varsfile/varsfile.go) |
+| Lockfile emitter (HCL output shape) | [`internal/lockfile/emit_hcl.go`](../internal/lockfile/emit_hcl.go) |
+| Registry emitter (HCL output shape) | [`internal/config/hclemit.go`](../internal/config/hclemit.go) |
+
+If you change the schema in any of these files, update this document
+in the same PR. See
+[INV-0002](investigation/0002-auto-generate-hcl-reference-doc.md) for the
+auto-generation analysis — until that lands, this doc is
+hand-maintained.
+
+## References
+
+- [DESIGN-0001 — Blueprint Authoring](design/0001-blueprint-authoring.md) — the authoring contract these specs implement.
+- [DESIGN-0002 — Registry layout and defaults inheritance](design/0002-registry-layout-and-defaults-inheritance.md) — `_defaults/` semantics.
+- [DESIGN-0004 — Unify config file format after HCL2 cutover](design/0004-unify-config-file-format-after-hcl2-cutover.md) — why HCL everywhere.
+- [DESIGN-0005 — Variable input via vars file](design/0005-variable-input-via-vars-file.md) — `.forge-vars.hcl` contract.
+- [ADR-0001 — Use HCL2 as the template engine](adr/0001-use-hcl2-as-the-template-engine.md).
+- [ADR-0002 — Forge does not ship in-tool migrators](adr/0002-forge-does-not-ship-in-tool-migrators.md).
+- [docs/MIGRATION.md](MIGRATION.md) — upgrade paths between format generations.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -28,7 +28,7 @@ docz create design "Your Design Title"
 - **Abandoned**: Design was not pursued
 
 <!-- BEGIN DOCZ AUTO-GENERATED -->
-## All DESIGNs
+## All Design
 
 | ID | Title | Status | Date | Author | Link |
 |----|-------|--------|------|--------|------|

--- a/docs/impl/0008-variable-input-via-vars-file.md
+++ b/docs/impl/0008-variable-input-via-vars-file.md
@@ -28,7 +28,7 @@ created: 2026-05-19
   - [Phase C: --var-file on forge sync](#phase-c---var-file-on-forge-sync)
     - [Tasks](#tasks-2)
     - [Success Criteria](#success-criteria-2)
-  - [Phase D: --var-file on forge check](#phase-d---var-file-on-forge-check)
+  - [Phase D: --var-file on forge check (rejection)](#phase-d---var-file-on-forge-check-rejection)
     - [Tasks](#tasks-3)
     - [Success Criteria](#success-criteria-3)
   - [Phase E: Documentation and release prep](#phase-e-documentation-and-release-prep)

--- a/docs/impl/README.md
+++ b/docs/impl/README.md
@@ -28,7 +28,7 @@ docz create impl "Your Implementation Title"
 - **Cancelled**: Plan was abandoned
 
 <!-- BEGIN DOCZ AUTO-GENERATED -->
-## All IMPLs
+## All Implementation Plans
 
 | ID | Title | Status | Date | Author | Link |
 |----|-------|--------|------|--------|------|
@@ -38,6 +38,6 @@ docz create impl "Your Implementation Title"
 | IMPL-0004 | Migrate Template Engine to HCL2 | Draft | 2026-05-07 | Donald Gifford | [0004-migrate-template-engine-to-hcl2.md](0004-migrate-template-engine-to-hcl2.md) |
 | IMPL-0005 | Unify Config File Format to HCL2 | Draft | 2026-05-12 | Donald Gifford | [0005-unify-config-file-format-to-hcl2.md](0005-unify-config-file-format-to-hcl2.md) |
 | IMPL-0006 | Migrate lockfile from YAML to HCL | Draft | 2026-05-18 | Donald Gifford | [0006-migrate-lockfile-from-yaml-to-hcl.md](0006-migrate-lockfile-from-yaml-to-hcl.md) |
-| IMPL-0007 | Remove forge migrate command | Draft | 2026-05-18 | Donald Gifford | [0007-remove-forge-migrate-command.md](0007-remove-forge-migrate-command.md) |
-| IMPL-0008 | Variable input via vars file | Draft | 2026-05-19 | Donald Gifford | [0008-variable-input-via-vars-file.md](0008-variable-input-via-vars-file.md) |
+| IMPL-0007 | Remove forge migrate command | Implemented | 2026-05-18 | Donald Gifford | [0007-remove-forge-migrate-command.md](0007-remove-forge-migrate-command.md) |
+| IMPL-0008 | Variable input via vars file | Accepted | 2026-05-19 | Donald Gifford | [0008-variable-input-via-vars-file.md](0008-variable-input-via-vars-file.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/investigation/0002-auto-generate-hcl-reference-doc.md
+++ b/docs/investigation/0002-auto-generate-hcl-reference-doc.md
@@ -1,0 +1,209 @@
+---
+id: INV-0002
+title: "auto-generate HCL reference doc"
+status: Open
+author: Donald Gifford
+created: 2026-06-25
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# INV 0002: auto-generate HCL reference doc
+
+**Status:** Open
+**Author:** Donald Gifford
+**Date:** 2026-06-25
+
+<!--toc:start-->
+- [Question](#question)
+- [Hypothesis](#hypothesis)
+- [Context](#context)
+- [Approach](#approach)
+- [Findings](#findings)
+  - [Observation 1: hcldec specs are already structured](#observation-1-hcldec-specs-are-already-structured)
+  - [Observation 2: hand-decoded schemas need a parallel path](#observation-2-hand-decoded-schemas-need-a-parallel-path)
+  - [Observation 3: prose can't be derived from code](#observation-3-prose-cant-be-derived-from-code)
+  - [Observation 4: CI staleness check is the cheap win](#observation-4-ci-staleness-check-is-the-cheap-win)
+- [Conclusion](#conclusion)
+- [Recommendation](#recommendation)
+- [References](#references)
+<!--toc:end-->
+
+## Question
+
+Can `docs/REFERENCE.md` be auto-generated from the Go source of truth
+(struct definitions, `hcldec` specs, validation constants) so the
+documented HCL surface stays in lockstep with the implementation
+without hand-editing every time the schema changes?
+
+## Hypothesis
+
+Yes for the *tables* (attributes, types, required/optional, allowed
+values) since those come from declarative Go data. No for the
+*prose* (the "Why this attribute exists" / "How it composes" / the
+code examples) — those are author intent, not derivable from the
+type system. A practical solution probably splits the doc into
+generated table sections and hand-authored narrative.
+
+## Context
+
+`docs/REFERENCE.md` was added in the same PR that opened this
+investigation — a hand-written reference covering `blueprint.hcl`,
+`registry.hcl`, `.forge-lock.hcl`, and `.forge-vars.hcl`. The
+maintenance risk is real: every IMPL that touches the HCL surface
+(IMPL-0004, IMPL-0005, IMPL-0006, IMPL-0008 in the last six months)
+would need to update REFERENCE.md or it rots silently. Three of the
+four files have already added or removed attributes during this
+period.
+
+**Triggered by:** REFERENCE.md initial draft (this branch).
+
+## Approach
+
+Evaluate three approaches without writing a generator yet:
+
+1. **Reflect over `hcldec.ObjectSpec` values at runtime** and emit
+   tables. The specs already encode attribute name, type, and
+   required-ness.
+2. **Walk Go AST + struct tags** with `go/ast` so we can pick up
+   field comments too.
+3. **Status quo + CI staleness check** — keep the hand-authored doc
+   but add a CI gate that fails if any of the source-of-truth files
+   change without REFERENCE.md changing.
+
+For each: estimate effort, accuracy, and what it can and cannot
+cover.
+
+## Findings
+
+### Observation 1: hcldec specs are already structured
+
+`internal/config/hcldec_spec.go` declares every blueprint and
+registry attribute as a `hcldec.ObjectSpec` value. Each entry
+carries:
+
+- the HCL attribute name (`Name` field on `AttrSpec`)
+- the cty type (`Type` field — gives us `cty.String`,
+  `cty.List(cty.String)`, etc.)
+- the `Required` flag
+
+Nested blocks are tagged with `hcldec.BlockSpec.TypeName`. Block
+labels are `hcldec.BlockLabelSpec`. **All of this is reachable
+through plain reflection at runtime** — no AST walk needed for the
+spec-driven parts of the schema.
+
+Estimated effort to emit the blueprint + registry attribute tables
+from these specs: ~1 day, including unit tests.
+
+### Observation 2: hand-decoded schemas need a parallel path
+
+Two block kinds are *not* in the eager `hcldec` specs:
+
+- `variable "name" { … }` — `default` and `validate` must be
+  captured as raw source bytes (templates referencing later-bound
+  variables). The schema lives in `variableBlockBodySchema`
+  (a plain `hcl.BodySchema`).
+- `condition { when = … }` — same reason. Lives in
+  `conditionBlockBodySchema`.
+
+Plus the `rename` block uses an outer/inner schema pair
+(`renameOuterBodySchema` + `renameEntryBodySchema`) for the same
+reason.
+
+These `hcl.BodySchema` values *are* still reflectable
+(`Attributes` slice with `Name` and `Required` fields), they just
+need a second code path because the type isn't `hcldec.ObjectSpec`.
+Doable but adds complexity.
+
+The `Lockfile` struct and the registry shape are fully covered by
+their eager specs, so no parallel-path issue there.
+
+### Observation 3: prose can't be derived from code
+
+About 40% of REFERENCE.md is prose:
+
+- "Why `default` is stringly-typed" (paragraph after the variable
+  table)
+- "How three-way merge works" (sync strategy descriptions)
+- Code examples for every section
+- Cross-references to design docs
+- The "Adding a new type means touching three sites" guide
+
+None of this is derivable from the type system. A generator would
+either:
+
+- emit empty placeholders the author fills in (regenerating wipes
+  the prose), or
+- merge generated tables into hand-authored prose via markers
+  (`<!-- AUTOGEN:blueprint-attributes -->` … `<!-- /AUTOGEN -->`),
+  preserving prose between sentinel pairs
+
+The marker approach is doable but ugly to review (giant diffs every
+time a type changes; hard to tell what a human meant vs what the
+generator chose to emit).
+
+### Observation 4: CI staleness check is the cheap win
+
+A shell one-liner in CI can catch the most common rot:
+
+```sh
+# .github/workflows/ci.yml
+- name: REFERENCE.md staleness check
+  run: |
+    SCHEMA_FILES=(
+      internal/config/blueprint.go
+      internal/config/registry.go
+      internal/config/hcldec_spec.go
+      internal/config/validate.go
+      internal/lockfile/lock.go
+      internal/lockfile/cty.go
+      internal/lockfile/emit_hcl.go
+      internal/varsfile/varsfile.go
+    )
+    if git diff --name-only origin/main...HEAD | grep -qE "$(IFS='|'; echo "${SCHEMA_FILES[*]}")"; then
+      git diff --name-only origin/main...HEAD | grep -q '^docs/REFERENCE.md$' \
+        || { echo "::error::Schema files changed without REFERENCE.md update"; exit 1; }
+    fi
+```
+
+Effort: ~30 minutes. Catches 80% of the rot risk (forgetting to
+update the doc when changing a schema). Doesn't catch "you updated
+both files but the doc and the code now disagree" — that one needs
+either generation or a careful reviewer.
+
+## Conclusion
+
+**Answer:** Partial. The attribute tables in REFERENCE.md *can* be
+auto-generated from the `hcldec` specs (Observation 1) plus a
+parallel path for the three hand-decoded schemas (Observation 2),
+but the prose and examples cannot (Observation 3). A full generator
+would need a marker-based merge strategy to preserve narrative
+content. The staleness-check (Observation 4) is the highest
+value-per-hour option and catches the most common failure mode at
+near-zero cost.
+
+## Recommendation
+
+Ship in two phases:
+
+1. **Now (this PR or a follow-up chore PR):** add the CI staleness
+   check from Observation 4. ~30 min of work. Catches "forgot to
+   update the doc when I added an attribute" — the most common
+   silent rot mode.
+2. **Later (separate IMPL when REFERENCE.md drift becomes painful):**
+   build a `cmd/gen-reference/` tool that reflects over the
+   `hcldec.ObjectSpec` and `hcl.BodySchema` values, emits attribute
+   tables between `<!-- AUTOGEN:* -->` markers, and exposes
+   `make docs-reference` + a CI check that regeneration produces no
+   diff. Skip until we feel the pain — REFERENCE.md is one file
+   and the schema doesn't change weekly.
+
+The staleness-check unblocks the rot risk today without committing
+to a generator we may never need.
+
+## References
+
+- [docs/REFERENCE.md](../REFERENCE.md) — the document this investigation is about.
+- [`internal/config/hcldec_spec.go`](../../internal/config/hcldec_spec.go) — the structured spec data a generator would reflect over.
+- [`internal/config/validate.go`](../../internal/config/validate.go) — the validation constants (`validVariableTypes`, `validSyncStrategies`).
+- [`internal/lockfile/lock.go`](../../internal/lockfile/lock.go), [`internal/lockfile/emit_hcl.go`](../../internal/lockfile/emit_hcl.go) — lockfile shape.
+- [`internal/varsfile/varsfile.go`](../../internal/varsfile/varsfile.go) — vars-file schema and coercion.

--- a/docs/investigation/README.md
+++ b/docs/investigation/README.md
@@ -9,11 +9,12 @@ Design docs, plans, and implementation docs can reference investigations by ID
 (e.g. `INV-0001`) to document how open questions were resolved.
 
 <!-- BEGIN DOCZ AUTO-GENERATED -->
-## All INVESTIGATIONs
+## All Investigations
 
 | ID | Title | Status | Date | Author | Link |
 |----|-------|--------|------|--------|------|
 | INV-0001 | Templating YAML Files and HCL2 Migration | Concluded | 2026-05-07 | Donald Gifford | [0001-templating-yaml-files-and-hcl2-migration.md](0001-templating-yaml-files-and-hcl2-migration.md) |
+| INV-0002 | auto-generate HCL reference doc | Open | 2026-06-25 | Donald Gifford | [0002-auto-generate-hcl-reference-doc.md](0002-auto-generate-hcl-reference-doc.md) |
 <!-- END DOCZ AUTO-GENERATED -->
 <!-- BEGIN DOCZ AUTO-GENERATED -->
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -6,7 +6,7 @@ implementation plan (how step-by-step). Use a plan when the scope is clear but
 the execution approach needs to be worked out before writing tasks.
 
 <!-- BEGIN DOCZ AUTO-GENERATED -->
-## All PLANs
+## All Plans
 
 | ID | Title | Status | Date | Author | Link |
 |----|-------|--------|------|--------|------|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
     - Investigations:
         - Overview: investigation/README.md
         - 'INV-0001: Templating YAML Files and HCL2 Migration': investigation/0001-templating-yaml-files-and-hcl2-migration.md
+        - 'INV-0002: auto-generate HCL reference doc': investigation/0002-auto-generate-hcl-reference-doc.md
     - Plans:
         - Overview: plan/README.md
         - 'PLAN-0001: Registry Blueprint and Update Commands': plan/0001-registry-blueprint-and-update-commands.md
@@ -39,7 +40,9 @@ nav:
     - Release Notes:
         - Release notes — v0.3.0 HCL2 template engine cutover: release-notes/v0.3.0-hcl2-cutover.md
         - Release notes — v0.4.0 HCL config-file unification: release-notes/v0.4.0-hcl-config.md
-        - Release notes — v0.5.0 HCL lockfile + forge migrate removed: release-notes/v0.5.0-hcl-lockfile.md
+        - Release notes — v0.5.0 HCL lockfile cutover + `forge migrate` removed: release-notes/v0.5.0-hcl-lockfile.md
+        - Release notes — v0.6.0 `--var-file` variable input: release-notes/v0.6.0-vars-file.md
+    - Forge HCL reference: REFERENCE.md
 plugins:
     - techdocs-core
 site_description: Documentation for forge


### PR DESCRIPTION
## Summary

- Adds `docs/REFERENCE.md` — the canonical reference for the four HCL formats forge reads and writes (`blueprint.hcl`, `registry.hcl`, `.forge-lock.hcl`, `.forge-vars.hcl`).
- Adds `docs/investigation/0002-auto-generate-hcl-reference-doc.md` (INV-0002) evaluating whether REFERENCE.md can be auto-generated from the Go source of truth, with a recommendation: ship a CI staleness check now, build a generator later if drift becomes painful.
- Links REFERENCE.md from the README's Documentation section.

## Why this PR

There was no single doc covering the HCL surface — schema knowledge was spread across `internal/config/hcldec_spec.go`, `internal/config/validate.go`, `internal/lockfile/*`, `internal/varsfile/varsfile.go`, plus the various DESIGN docs. Authoring a new blueprint or vars file required source-diving. REFERENCE.md is the single landing page; every claim links back to the Go file that owns it.

## Auto-generation analysis (INV-0002)

Quick summary of what the investigation found:
- ✅ Attribute tables *can* be reflected from `hcldec.ObjectSpec` values.
- ⚠️ Variable / condition / rename schemas need a parallel path (they use `hcl.BodySchema`, not `hcldec.ObjectSpec`).
- ❌ Prose, examples, and the "Adding a new type touches three sites" guidance can't be derived from code.
- 💡 A ~30-min CI staleness check catches the most common rot mode (forgetting to update the doc when changing a schema) at near-zero cost.

Recommendation in the INV: ship the staleness check soon; build the full generator only when REFERENCE.md drift becomes painful.

## Test plan

- [x] All cross-references in REFERENCE.md resolve (verified by reading; mkdocs build will catch any I missed).
- [x] `docz update` regenerated the doc indexes cleanly.
- [ ] mkdocs build / preview (will run when this hits CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)