### PR TITLE
docs: DESIGN-0006 + IMPL-0009 for object/collection variable types

### DIFF
--- a/docs/adr/0002-forge-does-not-ship-in-tool-migrators.md
+++ b/docs/adr/0002-forge-does-not-ship-in-tool-migrators.md
@@ -43,9 +43,9 @@ commands and contemplated two more:
 
 The migrate commands have served their purpose well for the
 *mechanical* format swaps (template syntax v1→v2, YAML→HCL configs).
-But the upcoming work package (RFC-0002 object/list/map types,
-choice→validation block, RFC-0003 locals + namespacing, IMPL-0006
-lockfile format) is **architecturally entangled**:
+But the upcoming work package (RFC-0002 / DESIGN-0006 object/list/map
+types and choice→validation block, RFC-0003 locals + namespacing,
+IMPL-0006 lockfile format) is **architecturally entangled**:
 
 - Namespacing every variable reference (`${X}` → `${var.X}`) is a
   mechanical transform, but the optional promotion of
@@ -116,7 +116,7 @@ rescaffold from the new blueprint version.
   outside `internal/migratecmd/`; removing both unblocks the
   dependency removal.
 - **Frees development bandwidth** for the architectural work
-  (RFC-0002, RFC-0003, IMPL-0006). Designing, building, and testing
+  (RFC-0002 / DESIGN-0006, RFC-0003, IMPL-0006). Designing, building, and testing
   migrators for an entangled multi-RFC change set would consume
   more cycles than the underlying work.
 - **Sharper release boundaries.** Each minor release has a clear
@@ -191,6 +191,7 @@ rescaffold from the new blueprint version.
 - [IMPL-0007 — Remove forge migrate command](../impl/0007-remove-forge-migrate-command.md) — removes existing migrate commands from the codebase per this decision.
 - [RFC-0003 — Locals for derived values](../rfc/0003-locals-for-derived-values.md) — drops Phase 4 (`forge migrate refs`) per this decision.
 - [RFC-0002 — Object and collection variable types](../rfc/0002-object-and-collection-variable-types.md) — semantic complexity (choice→validation reframing, object types) that informed the "too entangled for a migrator" argument.
+- [DESIGN-0006 — Object and collection variable types](../design/0006-object-and-collection-variable-types.md) — formalises RFC-0002's design and pins the migration story to the rescaffold/re-author pattern established by this ADR.
 - [IMPL-0004 — HCL2 cutover](../impl/0004-hcl2-cutover.md) — `forge migrate templates`, scheduled for removal under IMPL-0007.
 - [IMPL-0005 — Unify config file format to HCL2](../impl/0005-unify-config-file-format-to-hcl2.md) — `forge migrate config`, scheduled for removal under IMPL-0007.
 - [docs/MIGRATION.md](../MIGRATION.md) — the document that absorbs the migrator's former role.

--- a/docs/design/0005-variable-input-via-vars-file.md
+++ b/docs/design/0005-variable-input-via-vars-file.md
@@ -41,7 +41,7 @@ Add a `--var-file` flag to `forge create` (and `forge sync` / `forge check`
 where it applies) that loads variable values from an HCL document. This
 replaces the long `--set k=v --set k=v ...` chains that currently
 dominate non-trivial scaffold commands, and lays the input-side
-groundwork for object/list/map variable types (see RFC-0002).
+groundwork for object/list/map variable types (see RFC-0002, designed in DESIGN-0006).
 
 ## Goals and Non-Goals
 
@@ -75,8 +75,9 @@ groundwork for object/list/map variable types (see RFC-0002).
   parser handles it for free via hcldec's JSON support — wiring is
   trivial but adds CLI surface and tests. Defer to a follow-up.
 - **Object / list / map variable types.** Out of scope here — covered
-  by RFC-0002. This DESIGN ships with scalar-only support and the
-  file format naturally extends when object types land.
+  by RFC-0002 (designed in DESIGN-0006). This DESIGN ships with
+  scalar-only support and the file format naturally extends when
+  object types land.
 - **Lockfile format change.** Out of scope — covered by IMPL-0006.
 
 ## Background
@@ -114,8 +115,8 @@ Issues:
   given scaffolded project, separate from the lockfile (which lives
   inside the project).
 - **No path for non-scalar values.** `--set k=v` is fundamentally
-  scalar. When object/list/map types land (RFC-0002), there's no CLI
-  surface that can express them ergonomically.
+  scalar. When object/list/map types land (RFC-0002 / DESIGN-0006),
+  there's no CLI surface that can express them ergonomically.
 - **Documentation surface.** A `.forge-vars.hcl` checked in next to
   a scaffolded project is a self-documenting input artifact.
 
@@ -138,7 +139,7 @@ project_owner       = "donaldgifford"
 project_description = "A lightweight, embeddable Okta mock for Terraform tests"
 git_provider        = "github"
 
-# When object types land (RFC-0002), this just works:
+# When object types land (RFC-0002 / DESIGN-0006), this just works:
 # git_provider = {
 #   repo_type   = "github"
 #   repo_url    = "github.com"
@@ -387,6 +388,7 @@ No release-notes pressure since the feature is additive.
 - [DESIGN-0004 — Unify config file format after HCL2 cutover](0004-unify-config-file-format-after-hcl2-cutover.md) — precedent for "HCL everywhere" consistency.
 - [IMPL-0006 — Migrate lockfile from YAML to HCL](../impl/0006-migrate-lockfile-from-yaml-to-hcl.md) — parallel format consistency work.
 - [RFC-0002 — Object and collection variable types](../rfc/0002-object-and-collection-variable-types.md) — the long-tail feature this DESIGN unblocks on the input side.
+- [DESIGN-0006 — Object and collection variable types](0006-object-and-collection-variable-types.md) — RFC-0002's design; vars-file parser delegates to `cty.Convert` for structured types per DESIGN-0006's `--var-file` section.
 - [RFC-0003 — Locals for derived values](../rfc/0003-locals-for-derived-values.md) — defines the `var.NAME` / `local.NAME` namespacing used in templates and conditions; vars files keep bare keys.
 - [Terraform `-var-file` documentation](https://developer.hashicorp.com/terraform/language/values/variables#variable-definitions-tfvars-files) — direct inspiration; the precedence-rules wart in Terraform's design is what motivates the mutual-exclusion rule here.
 - `internal/lockfile/cty.go` — existing `cty.Value` coercion machinery this design reuses.

--- a/docs/design/0006-object-and-collection-variable-types.md
+++ b/docs/design/0006-object-and-collection-variable-types.md
@@ -1,0 +1,779 @@
+---
+id: DESIGN-0006
+title: "object and collection variable types"
+status: Draft
+author: Donald Gifford
+created: 2026-06-29
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# DESIGN 0006: object and collection variable types
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-06-29
+
+<!--toc:start-->
+- [Overview](#overview)
+- [Goals and Non-Goals](#goals-and-non-goals)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Background](#background)
+  - [Current state](#current-state)
+  - [Why now](#why-now)
+- [Detailed Design](#detailed-design)
+  - [Type system](#type-system)
+  - [Declaration syntax](#declaration-syntax)
+  - [Type expression parser](#type-expression-parser)
+  - [Default value evaluation](#default-value-evaluation)
+  - [Validation block (`choice` replacement)](#validation-block-choice-replacement)
+  - [Input via `--var-file`](#input-via---var-file)
+  - [Input via `--set`](#input-via---set)
+  - [Prompt UX](#prompt-ux)
+  - [Template access](#template-access)
+  - [Lockfile representation](#lockfile-representation)
+  - [Error surfacing](#error-surfacing)
+- [API / Interface Changes](#api--interface-changes)
+  - [Blueprint schema (HCL)](#blueprint-schema-hcl)
+  - [Go types](#go-types)
+  - [CLI](#cli)
+- [Data Model](#data-model)
+- [Testing Strategy](#testing-strategy)
+- [Migration / Rollout Plan](#migration--rollout-plan)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Overview
+
+Lift forge's variable type model from the current four-string-tag enum
+(`string`, `bool`, `int`, `choice`) to a subset of cty's type
+expression grammar — adding `object({…})`, `list(T)`, and `map(T)` —
+and replace the bespoke `choice` type with a Terraform-style
+`validation { condition = …, error_message = … }` block. Authors group
+related fields under a single structured variable; templates access
+nested values via standard HCL2 attribute syntax; vars files carry
+nested values natively. Implements [RFC-0002](../rfc/0002-object-and-collection-variable-types.md).
+
+## Goals and Non-Goals
+
+### Goals
+
+- Add `object({…})`, `list(T)`, and `map(T)` to the variable type
+  surface alongside the existing `string`/`bool`/`int` scalars.
+- Replace `type = "choice"` + `choices = [...]` and the scalar-only
+  `validate = "regex"` field with a Terraform-style
+  `validation { condition = …, error_message = … }` block. One
+  validation mechanism, composes into object fields naturally.
+- Keep the change additive on the value-flow side: templates, lockfile,
+  and `forge sync`/`check` continue to operate on `cty.Value` without
+  new code paths.
+- Preserve "make CI ergonomic" — vars-file is the primary input path
+  for non-scalar values; the prompt UX degrades gracefully (objects
+  unfold to per-field prompts; lists/maps error with a copy-pasteable
+  vars-file pointer when required-and-unsupplied).
+- Surface type-mismatch errors with HCL file:line:col so authors and
+  users see the source of the problem.
+
+### Non-Goals
+
+- `tuple([…])` (heterogeneous fixed-length), `set(T)` (deduplicated),
+  and optional object fields. Add later behind separate proposals if
+  real demand surfaces.
+- `null` values. Every declared variable must have a non-null resolved
+  value, either from input or default.
+- An interactive TUI widget for list/map input. Deliberate trade-off:
+  TUI sequences are hard to do well and vars files are the better path
+  for non-scalar input anyway.
+- A first-class `prompt { kind = "select", options = [...] }` block to
+  re-introduce the legacy `choice` type's select-list UX. The
+  validation block replaces `choice`'s constraint role; the lost
+  select-list UX is documented as a known v0.7 regression and tracked
+  for a follow-up RFC.
+- An in-tool migrator for legacy `choice` / `choices` / scalar-only
+  `validate` declarations. Per ADR-0002, authors re-declare under the
+  new form when adopting v0.7.
+- `locals { … }` for derived values — sibling concern, tracked in
+  [RFC-0003](../rfc/0003-locals-for-derived-values.md). Composes with
+  this DESIGN but ships independently.
+
+## Background
+
+### Current state
+
+forge variables are flat scalars declared in `blueprint.hcl`:
+
+```hcl
+variable "project_name" {
+  type     = "string"
+  required = true
+  validate = "^[a-z][a-z0-9-]*$"
+}
+
+variable "license" {
+  type    = "choice"
+  choices = ["Apache-2.0", "MIT", "BSD-3-Clause"]
+  default = "Apache-2.0"
+}
+```
+
+The Go struct (`internal/config/blueprint.go`) and HCL schema
+(`internal/config/hcldec_spec.go`) both hard-code this surface:
+
+```go
+type Variable struct {
+    Name        string
+    Description string
+    Type        string   // ← string tag from the allow-list
+    Default     string
+    Required    bool
+    Validate    string   // ← scalar-only regex
+    Choices     []string // ← lives parallel to Type
+}
+```
+
+Validation (`internal/config/validate.go`) checks `Type` against a
+four-element allow-list (`validVariableTypes`) and gates `Choices`
+required-ness when `Type == "choice"`.
+
+Resolved values already flow as `cty.Value` from `internal/prompt`
+through `internal/lockfile` and `internal/template` — the
+on-the-wire type surface is the constrained part; the in-memory value
+plumbing is already nested-value-ready.
+
+`internal/varsfile` (post-IMPL-0008) parses `.forge-vars.hcl`
+attributes and coerces them against `Variable.Type` via
+`cty/convert`. The parser today bails on non-scalar values; the
+package was deliberately structured so RFC-0002's types drop in
+without restructuring.
+
+### Why now
+
+Three signals converging:
+
+1. **Real registry pain.** The forge-registry renovate-config use case
+   needs four derived-default variables (`git_provider_host`,
+   `project_org`, `renovate_config_repo`, …) computed from one user
+   choice. The same pattern repeats per blueprint. The variable
+   surface is mostly noise; the logical concept is splintered.
+
+2. **`choice` is a half-feature.** It encodes one specific kind of
+   string constraint but blocks composition — there's no way to put
+   a `choice` constraint on a field inside an object. Replacing it
+   with a generic validation block unblocks both object fields *and*
+   regex / range / length constraints that `validate` covered
+   awkwardly.
+
+3. **The value pipeline is already cty-native.** `cty.Value`
+   round-trips cleanly through `hclwrite`, the template engine, and
+   the prompt resolver. The constraint that turns this into a
+   feature is the *type-declaration* surface — everything downstream
+   is essentially free.
+
+## Detailed Design
+
+### Type system
+
+A subset of cty's type expression grammar. The full grammar is more
+than forge needs; we limit it to the forms that compose without
+surprising authors:
+
+| Form | Example | cty equivalent |
+|------|---------|----------------|
+| `string` | `type = string` | `cty.String` |
+| `bool` | `type = bool` | `cty.Bool` |
+| `number` (alias `int`, deprecated) | `type = number` (canonical) or `type = int` (deprecated; warns at load time) | `cty.Number` |
+| `list(T)` | `type = list(string)` | `cty.List(T)` |
+| `map(T)` | `type = map(string)` | `cty.Map(T)` |
+| `object({k = T, …})` | `type = object({port = number, host = string})` | `cty.Object(map[string]cty.Type{…})` |
+
+> **Why no `tuple`/`set`/`optional`?** Smaller surface = fewer edge
+> cases in prompts, validation, and lockfile round-trip. Nothing in
+> the current registry corpus needs them. Add later if a real use
+> case appears — the type parser is structured to grow.
+
+**Backwards compatibility shim.** The existing quoted-string forms
+(`type = "string"`, `type = "bool"`, `type = "int"`) continue to parse
+during the v0.7 transition window. The unquoted bareword forms are
+the new canonical syntax; quoted forms are accepted but the docs
+guide authors toward unquoted. `type = "choice"` is **not** accepted
+— it triggers a load-time error pointing at the validation-block
+migration pattern in MIGRATION.md.
+
+**`int` deprecation warning.** Both `type = int` and the legacy
+`type = "int"` continue to resolve to `cty.Number` (per
+[OQ-6](#open-questions)) but `LoadBlueprint` emits a one-line
+deprecation warning naming the variable and source location, with a
+pointer to the canonical `type = number` form. The warning fires
+once per declaration. A future release may promote it to a
+load-time error — this DESIGN does not commit to when.
+
+> **Type tags vs type expressions.** The legacy schema treated `type`
+> as a string literal; the new schema treats `type` as an HCL
+> expression captured at load time. The parser inspects the
+> expression shape and resolves it to a `cty.Type`. This mirrors how
+> `Condition.When` is already captured as an `hcl.Expression` at
+> load time with the source kept on `WhenSource` for round-tripping.
+
+### Declaration syntax
+
+```hcl
+# Scalar (unchanged on the value side; type form is now an expression)
+variable "project_name" {
+  description = "Service name"
+  type        = string
+  required    = true
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]*$", var.project_name))
+    error_message = "project_name must be lowercase kebab-case."
+  }
+}
+
+# Object — required, no default
+variable "auth_provider" {
+  description = "OIDC issuer configuration"
+  type = object({
+    kind   = string
+    issuer = string
+  })
+  required = true
+}
+
+# Object — derived default from another variable
+variable "git_provider" {
+  type = object({
+    repo_type   = string
+    repo_url    = string
+    project_org = string
+  })
+  default = var.git_provider_kind == "github" ? {
+    repo_type   = "github"
+    repo_url    = "github.com"
+    project_org = "donaldgifford"
+  } : {
+    repo_type   = "forgejo"
+    repo_url    = "git.fartlab.dev"
+    project_org = "homelab"
+  }
+}
+
+# List
+variable "exposed_ports" {
+  description = "TCP ports the service exposes"
+  type        = list(number)
+  default     = [8080]
+}
+
+# Map
+variable "build_targets" {
+  description = "OS → goarch matrix"
+  type        = map(string)
+  default = {
+    linux  = "amd64"
+    darwin = "arm64"
+  }
+}
+```
+
+Required-ness applies uniformly: `required = true` with no `default`
+means the user must supply a value (via vars-file, `--set` for
+scalars/objects, or prompt for scalars/objects). Required list/map
+without input is a clean error (see [Prompt UX](#prompt-ux)).
+
+### Type expression parser
+
+A new internal helper:
+
+```go
+// parseVariableType resolves the variable's `type` HCL expression to
+// a cty.Type. Accepts bareword scalars (string, bool, number, int),
+// the legacy quoted-string forms during the v0.7 transition, and the
+// cty constructor forms (object({...}), list(T), map(T)).
+func parseVariableType(expr hcl.Expression) (cty.Type, error)
+```
+
+Lives in `internal/config/vartype.go` (new file). The implementation
+uses cty's `typeexpr` package — it already supports the exact subset
+forge wants, including the quoted-string scalar fallback for
+backwards compatibility:
+
+```go
+import "github.com/hashicorp/hcl/v2/ext/typeexpr"
+
+ty, diags := typeexpr.Type(expr)
+```
+
+`typeexpr` returns descriptive errors for `tuple`, `set`, and
+optional fields — wrap those with a forge-specific "this type is not
+supported in forge variables" message so users don't dead-end on
+cty-flavoured diagnostics.
+
+The parser runs at `LoadBlueprint` time so type errors surface with
+file:line:col immediately, not on first prompt or first render.
+
+### Default value evaluation
+
+Defaults move from "string captured raw, re-rendered through the
+template engine" to "HCL expression captured at load time, evaluated
+against the variable scope when the variable is resolved." This
+mirrors how `Condition.When` already works.
+
+The new flow:
+
+1. At load time: capture `default` as `hcl.Expression`; keep
+   `WhenSource`-equivalent (`DefaultSource`) for diagnostics and the
+   lockfile snapshot.
+2. At resolve time: evaluate the expression against the already-bound
+   `var.*` scope, producing a `cty.Value`.
+3. Type-check the result against the declared `cty.Type` via
+   `cty.Convert`. Mismatches surface with file:line:col of the
+   `default` expression.
+
+This change subsumes the current `renderDefault` call in
+`internal/prompt`; the existing path stays as a fallback for the
+backwards-compatibility shim during v0.7.
+
+### Validation block (`choice` replacement)
+
+A repeatable nested block on `variable`:
+
+```hcl
+variable "git_provider_kind" {
+  type    = string
+  default = "github"
+  validation {
+    condition     = contains(["github", "forgejo"], var.git_provider_kind)
+    error_message = "git_provider_kind must be one of: github, forgejo."
+  }
+}
+```
+
+| Attribute | Type | Required | Notes |
+|---|---|---|---|
+| `condition` | `hcl.Expression` (bool) | yes | Evaluated against the resolved variable scope. Must return `bool`. |
+| `error_message` | string | yes | Surfaced verbatim on failure. **No interpolation in v1** — keeps the error surface predictable. |
+
+Multiple validation blocks per variable stack; all must pass. The
+condition expression is captured at load time (parse-time syntax
+errors surface immediately); evaluated at resolve time against the
+variable scope.
+
+**Object-field constraints** compose cleanly because the validation
+lives on the variable, not inside the type expression:
+
+```hcl
+variable "git_provider" {
+  type = object({
+    kind = string
+    url  = string
+  })
+  validation {
+    condition     = contains(["github", "forgejo"], var.git_provider.kind)
+    error_message = "git_provider.kind must be one of: github, forgejo."
+  }
+}
+```
+
+**List/map constraints** work element-wise via standard cty
+functions:
+
+```hcl
+variable "exposed_ports" {
+  type = list(number)
+  validation {
+    condition     = alltrue([for p in var.exposed_ports : p > 0 && p < 65536])
+    error_message = "exposed_ports must all be valid TCP port numbers."
+  }
+}
+```
+
+**Removed fields.** Both `choices = [...]` and the scalar-only
+`validate = "regex"` are rejected at load time with an error
+pointing at the new validation-block pattern in MIGRATION.md. No
+in-tool migrator (ADR-0002).
+
+### Input via `--var-file`
+
+No syntax additions required — HCL natively supports nested values:
+
+```hcl
+# project.forge-vars.hcl
+project_name  = "mockta"
+exposed_ports = [8080, 9090]
+git_provider = {
+  repo_type   = "github"
+  repo_url    = "github.com"
+  project_org = "donaldgifford"
+}
+build_targets = {
+  linux  = "amd64"
+  darwin = "arm64"
+}
+```
+
+The vars-file parser (`internal/varsfile`) already loads attribute
+values as `cty.Value`. Today it bails on non-scalar values during
+coercion; with this DESIGN it delegates to `cty.Convert` against the
+declared type, which handles structured values transparently. The
+strict-literal posture (no function calls, no traversals) stays —
+the legality of the value itself is unchanged.
+
+This is the primary intended input path for non-scalar values.
+
+### Input via `--set`
+
+`--set` semantics:
+
+| Variable type | `--set` behaviour |
+|---|---|
+| `string`, `bool`, `int`, `number` | Unchanged. `--set port=8080`. |
+| `object({…})` | Top-level replacement only via HCL literal: `--set 'git_provider={repo_type="github",...}'`. **No dotted-path field overrides** in v1 — they only make sense composed with `--var-file`, which DESIGN-0005 explicitly forbids on the same invocation. |
+| `list(T)` | Not supported. Error: `"--set on variable X (list(...)) is not supported; use --var-file"`. |
+| `map(T)` | Not supported. Same error. |
+
+Per RFC-0002 OQ-1 (resolved: option 1), the `--var-file` + `--set`
+mutex from DESIGN-0005 stays intact. Users who want layered values
+compose multiple `--var-file` invocations.
+
+### Prompt UX
+
+`internal/prompt` extends the existing charmbracelet/huh-based flow:
+
+**Scalars** — unchanged. Same widget per type.
+
+**Objects** — unfold into per-field prompts in declaration order:
+
+```text
+? git_provider.repo_type [github]: ▮
+? git_provider.repo_url [github.com]:
+? git_provider.project_org [donaldgifford]:
+```
+
+Per-field defaults come from the resolved object default (so the
+ternary-driven default pattern under [Declaration syntax](#declaration-syntax)
+works as expected). The dotted prompt label is purely cosmetic — the
+resolved value is reconstructed as a single `cty.Value` before being
+passed to the renderer. No new widget type required.
+
+Nested objects unfold recursively: `git_provider.endpoints.primary`.
+Lists/maps inside an object follow the same non-interactive rule as
+top-level lists/maps (see below).
+
+**Lists and maps** — non-interactive. If required and unsupplied,
+fail with a copy-pasteable vars-file pointer:
+
+```text
+Error: variable "exposed_ports" (list(number)) is required but cannot
+be supplied interactively.
+
+Provide it via --var-file:
+
+    # project.forge-vars.hcl
+    exposed_ports = [8080, 9090]
+
+    forge create ... --var-file ./project.forge-vars.hcl
+```
+
+If a list/map has a `default` and the user hasn't overridden it, the
+default flows through silently — same as a scalar with a default.
+
+**Lost UX: the legacy `choice` select-list.** Documented v0.7
+regression. Enum-constrained strings default to free-text input plus
+validation rejecting bad values. Follow-up RFC tracks adding an
+optional `prompt { kind = "select", options = [...] }` block to
+re-introduce the select-list UX without coupling it to the type
+system.
+
+### Template access
+
+Standard HCL2 attribute and index syntax — the renderer already
+evaluates this because `cty.Value` is the underlying value type:
+
+```text
+# In a .tmpl file (var.* namespace per RFC-0003 — see Open Questions):
+host:    ${var.git_provider.repo_url}
+org:     ${var.git_provider.project_org}
+primary: ${var.exposed_ports[0]}
+linux:   ${var.build_targets["linux"]}
+
+# Iteration via existing HCL2 for directive:
+%{ for port in var.exposed_ports ~}
+- containerPort: ${port}
+%{ endfor ~}
+
+# Conditional access:
+%{ if var.git_provider.repo_type == "github" ~}
+.github/...
+%{ endif ~}
+```
+
+**Namespace open question.** RFC-0003 introduces the `var.*`
+namespace for variable references. This DESIGN assumes that
+namespace lands first (or co-lands). If RFC-0003 slips, templates
+keep using bare-name references and this DESIGN's examples flip
+back. See [Open Questions OQ-1](#open-questions) for the sequencing
+choice.
+
+The only renderer adjustment is the strict-vars check —
+`internal/template` validates that template-referenced variables are
+declared in `blueprint.hcl`. The new check allows nested attribute
+access against declared object types: `var.git_provider.repo_type`
+is legal iff `git_provider` is declared as
+`object({repo_type = …, …})`.
+
+### Lockfile representation
+
+The HCL lockfile (post-IMPL-0006) carries nested values natively:
+
+```hcl
+variables {
+  project_name  = "mockta"
+  exposed_ports = [8080, 9090]
+  git_provider = {
+    repo_type   = "github"
+    repo_url    = "github.com"
+    project_org = "donaldgifford"
+  }
+  build_targets = {
+    linux  = "amd64"
+    darwin = "arm64"
+  }
+}
+```
+
+`cty.Value` round-trips through `hclwrite` cleanly. `internal/lockfile/cty.go`
+already houses the `ToCtyValues`/`FromCtyValues` pair that this DESIGN
+extends — the existing scalar branches stay; object/list/map branches
+delegate to `cty/convert` directly. The variable-type-aware coercion
+already in `ToCtyValues` is the natural home for the new shapes.
+
+`forge check` and `forge sync` re-derive values from the lockfile
+exactly as they do for scalars today. The drift-detection hash logic
+is unchanged — it hashes rendered file content, not variable values.
+
+### Error surfacing
+
+Three new error classes; all carry HCL `Range` info:
+
+| Error class | Surfaces at | Message shape |
+|---|---|---|
+| Type-expression parse error | `LoadBlueprint` | `blueprint.hcl:L:C: invalid type expression for variable "X": <reason>` |
+| Default-value type mismatch | `LoadBlueprint` | `blueprint.hcl:L:C: default for variable "X" does not match declared type: expected <T>, got <U>` |
+| Validation-condition failure | resolve time | `<error_message> (variable "X", blueprint.hcl:L:C)` |
+| `type = int` deprecation (warning, not error) | `LoadBlueprint` | `blueprint.hcl:L:C: variable "X": type = int is deprecated; use type = number` |
+
+Coercion errors from vars files keep the existing format
+(`vars file PATH:L:C: variable "X" expects T, got U`).
+
+## API / Interface Changes
+
+### Blueprint schema (HCL)
+
+| Field | Today | After this DESIGN |
+|---|---|---|
+| `variable.type` | string scalar from `{string, bool, int, choice}` | HCL expression resolving to a `cty.Type` from `{string, bool, number, int, list(T), map(T), object({…})}`. Quoted-string scalars accepted during transition. |
+| `variable.choices` | required when `type = "choice"` | **removed** — load-time error pointing at MIGRATION.md |
+| `variable.validate` | optional regex string | **removed** — load-time error pointing at MIGRATION.md |
+| `variable.default` | string captured raw | HCL expression evaluated against the variable scope at resolve time |
+| `validation { condition, error_message }` | does not exist | **new** repeatable block on `variable` |
+
+### Go types
+
+```go
+// internal/config/blueprint.go
+type Variable struct {
+    Name          string
+    Description   string
+    Type          cty.Type        // ← was string
+    TypeSource    string          // raw source for diagnostics
+    DefaultExpr   hcl.Expression  // ← was Default string
+    DefaultSource string          // raw source for diagnostics
+    Required      bool
+    Validations   []Validation    // ← new
+
+    // Removed: Validate, Choices
+}
+
+type Validation struct {
+    Condition     hcl.Expression
+    ErrorMessage  string
+    DefRange      hcl.Range // for error attribution
+}
+```
+
+The struct-comment migration story: a one-line comment explains
+that the type/default expression-capture mirrors `Condition.When`,
+and points readers at `parseVariableType` in
+`internal/config/vartype.go`.
+
+### CLI
+
+No new flags. Existing flags get extended error messages:
+
+- `--set` rejects list/map values with the message in
+  [Input via `--set`](#input-via---set).
+- `--var-file` coercion errors now surface object/list/map type
+  mismatches via the existing
+  `vars file PATH:L:C: variable "X" expects T, got U` format.
+
+## Data Model
+
+| Surface | Storage | Shape |
+|---|---|---|
+| Blueprint variable type | in-memory `cty.Type` (from `typeexpr.Type`) | matches cty's `Object`/`List`/`Map` constructors |
+| Blueprint variable default | in-memory `hcl.Expression` (lazy-evaluated) | source preserved in `DefaultSource` |
+| Resolved variable value | `cty.Value` end-to-end (already true today) | passes through `ToCtyValues` → lockfile → template renderer |
+| Lockfile `variables { … }` block | HCL native nested attributes | `hclwrite` round-trips object/list/map without escaping |
+| `.forge-vars.hcl` input | HCL native nested attributes | parser unchanged; coercion delegates to `cty.Convert` |
+
+No new on-disk format. No new lockfile schema. The "no schema
+change" property is the architectural payoff of having a
+`cty.Value`-native value pipeline.
+
+## Testing Strategy
+
+| Layer | Coverage |
+|---|---|
+| Type expression parser | Table-driven: each accepted form (`string`, `bool`, `number`, `int`, `list(T)`, `map(T)`, `object({…})`, nested object, quoted-string legacy forms). Each rejected form (`tuple`, `set`, `optional`, `"choice"`) with the expected error pointing at MIGRATION.md. |
+| Default expression evaluation | Per type: literal defaults, derived-from-another-variable defaults, type-mismatched defaults (expects clean error with file:line:col). |
+| Validation block | Single block, multiple stacked blocks, validation against an object field, validation against a list element via `alltrue([for …])`, validation failure surfaces `error_message` verbatim. |
+| Removed-field rejection | `choices = [...]` and `validate = "regex"` both produce load-time errors pointing at MIGRATION.md. |
+| `internal/varsfile` integration | Vars files supplying object/list/map values; coercion against the declared `cty.Type`; type-mismatch errors with `vars file PATH:L:C` location. |
+| `--set` integration | Top-level object replacement via HCL literal; list/map values produce the documented error message. |
+| Prompt UX | Object unfold (per-field prompts), nested-object unfold, required-list-with-no-input error with copy-pasteable vars-file snippet, default-flowing list (no prompt). |
+| Lockfile round-trip | Write → load cycle on a project with object + list + map + nested-object variables; assert byte-identity. |
+| Template strict-vars | `var.obj.field` legal iff field is declared; `var.list[0]` legal iff `list` is declared as `list(T)`; bad references error with file:line:col. |
+| End-to-end | Integration test scaffolding the forge-registry renovate-config use case (one `git_provider` object variable replacing four scalar variables); assert the rendered output matches a fixture. |
+| Cross-RFC composition | If RFC-0003 (locals) lands first, integration test combining a local that references an object variable's field. |
+
+Test corpus lives in `internal/config/testdata/object-types/` and
+`internal/varsfile/testdata/object-types/`; both directories follow
+the per-fixture pattern already established by IMPL-0008.
+
+## Migration / Rollout Plan
+
+**Release line.** Minor bump — v0.7.0 per RFC-0002 OQ-4. Bundled
+with RFC-0003 (locals) if both land in the same window. Out of band
+of any other format change (the v0.5/v0.6 release line covered HCL
+format consolidation and vars-file).
+
+**Breaking changes for blueprint authors.**
+
+1. `type = "choice"` → re-declare as `type = string` plus a
+   `validation { condition = contains([...], var.X) }` block.
+2. `choices = [...]` field → **removed**. Carried by the validation
+   block above.
+3. `validate = "regex"` field → re-declare as
+   `validation { condition = can(regex("...", var.X)) }`.
+4. `type = "string"` / `type = "bool"` **continue to work
+   silently** during the v0.7 transition (quoted-string fallback in
+   the parser). Authors are guided toward the bareword forms in
+   docs but the load-time validator does not warn on the quoted
+   forms.
+5. `type = int` (and the legacy `type = "int"`) continue to work
+   but emit a **deprecation warning** at load time. Authors
+   migrate to `type = number`. See [OQ-6](#open-questions).
+
+**Author migration walkthrough.** A new section in
+`docs/MIGRATION.md` (`## Variable type system upgrade (v0.7+)`)
+covers each breaking change with a before/after snippet and a
+copy-pasteable pattern.
+
+**No project-side migration.** Existing lockfiles continue to load
+unchanged — the `variables { … }` block already carries native HCL
+primitives (post-IMPL-0006), and the lockfile loader has no opinion
+on whether a variable's declared type is a scalar or a structured
+type. A scaffolded project from a pre-v0.7 blueprint stays valid;
+re-running `forge sync` after a blueprint adopts new structured
+types may surface "variable X newly declared with no default" if
+the author also marked it required, but that's a content change,
+not a format change.
+
+**Project consumer impact.** None for projects that don't update
+their source blueprint. Projects whose source blueprint adopts
+v0.7 features see the changes the next time they run
+`forge sync`.
+
+**Sequencing.** Three phases for the implementation IMPL doc to
+break out, kept abstract here:
+
+1. Type expression + default expression + validation block (the
+   schema-side change).
+2. Vars-file / `--set` / prompt UX integration (the input-side
+   change).
+3. Documentation, migration guide, release notes.
+
+The IMPL doc owns the concrete task breakdown and acceptance gates.
+
+## Open Questions
+
+- **OQ-1: Sequencing with RFC-0003 (locals / `var.*` namespace).**
+  RFC-0003 introduces `var.*` for variable references in templates
+  and defaults. This DESIGN's examples assume `var.*` is available.
+  **Decision: option 2 — ship both in v0.7.0 simultaneously.**
+  Single migration story for authors; templates and the
+  validation-condition scope reference the same `var.*` namespace
+  end-to-end. Coordination cost accepted. The IMPL doc owns the
+  cross-stream task ordering.
+
+- **OQ-2: Should `parseVariableType` use cty's `typeexpr` package
+  directly, or reimplement?** **Decision: use `typeexpr` directly.**
+  It covers the exact subset forge wants, is the same parser
+  Terraform uses (matching user intuition on error messages), and
+  reimplementing buys nothing except control. Wrap errors with
+  forge-specific phrasing where the raw cty diagnostic would
+  dead-end users (e.g. `tuple`, `set`, optional fields).
+
+- **OQ-3: Validation-block `error_message` interpolation.**
+  **Decision: static string only in v1.** Terraform allows
+  `${...}` references inside `error_message`; forge does not.
+  Keeps the error surface predictable and avoids the "what does
+  this template see?" question. Revisit if real demand surfaces.
+
+- **OQ-4: Should validation conditions see *other* variables in
+  scope?** **Decision: yes, allow cross-variable references; the
+  scope is the same as default-expression evaluation.** Adds zero
+  implementation surface (the resolved-variable scope is already
+  built for defaults) and unlocks "this value must agree with that
+  one" constraints. Matches Terraform's semantics.
+
+- **OQ-5: Lost `choice` select-list UX — release blocker or
+  acknowledged regression?** **Decision: ship v0.7 with the UX
+  regression; document it; track a follow-up RFC for
+  `prompt { kind = "select", options = [...] }`.** The validation
+  reframing is the architectural payoff; the prompt regression is
+  a cosmetic bug we can fix in a follow-up without re-litigating
+  the type system. Release notes call out the regression
+  explicitly with the migration path (validation block) and a
+  forward pointer to the follow-up RFC slot.
+
+- **OQ-6: What's the policy on `type = "number"` vs `type = "int"`?**
+  **Decision: treat `int` as an alias for `number` (current implicit
+  behaviour) and emit a deprecation warning at `LoadBlueprint` time
+  when authors use `int`.** The warning fires once per blueprint
+  load, carries the variable name and source location, and points
+  at the migration: `type = int → type = number`. Docs guide
+  authors toward `number` as the canonical form. A future release
+  (likely v0.8 or v0.9) may promote the warning to a load-time
+  error; this DESIGN does not commit to that step.
+
+## References
+
+- [RFC-0002 — Object and collection variable types](../rfc/0002-object-and-collection-variable-types.md) — the proposal this DESIGN implements.
+- [RFC-0003 — Locals for derived values](../rfc/0003-locals-for-derived-values.md) — companion proposal for derived-value separation; co-evolves with this DESIGN.
+- [DESIGN-0001 — Blueprint Authoring](0001-blueprint-authoring.md) — the variable-declaration contract this DESIGN extends.
+- [DESIGN-0005 — Variable input via vars file](0005-variable-input-via-vars-file.md) — input mechanism that unblocks non-scalar values on the CLI side.
+- [IMPL-0006 — Migrate lockfile from YAML to HCL](../impl/0006-migrate-lockfile-from-yaml-to-hcl.md) — lockfile format that nesting depends on for clean round-trips. **Already shipped.**
+- [IMPL-0008 — Variable input via vars file](../impl/0008-variable-input-via-vars-file.md) — vars-file parser, structured so this DESIGN's types drop in without restructuring.
+- [ADR-0001 — Use HCL2 as the template engine](../adr/0001-use-hcl2-as-the-template-engine.md).
+- [ADR-0002 — Forge does not ship in-tool migrators](../adr/0002-forge-does-not-ship-in-tool-migrators.md) — governs the `choice` / `choices` / `validate` removal.
+- [Terraform `validation` block](https://developer.hashicorp.com/terraform/language/values/variables#custom-validation-rules) — direct prior art for the validation syntax and semantics adopted here.
+- [Terraform variable type constraints](https://developer.hashicorp.com/terraform/language/values/variables#type-constraints) — direct prior art for the type expression grammar.
+- [`zclconf/go-cty` type expressions](https://github.com/zclconf/go-cty/blob/main/docs/types.md) — type system this DESIGN adopts a subset of.
+- [`hashicorp/hcl/v2/ext/typeexpr`](https://pkg.go.dev/github.com/hashicorp/hcl/v2/ext/typeexpr) — the parser this DESIGN delegates to.
+- `internal/config/blueprint.go` — Variable struct that gains the parsed type.
+- `internal/config/hcldec_spec.go` — variable block schema to extend.
+- `internal/config/validate.go` — `validVariableTypes` map that becomes unnecessary.
+- `internal/prompt/prompt.go` — prompt flow that gains object unfolding.
+- `internal/lockfile/cty.go` — value coercion machinery already in place.
+- `internal/varsfile/varsfile.go` — vars-file coercion that gains structured-value support.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -37,4 +37,5 @@ docz create design "Your Design Title"
 | DESIGN-0003 | Migrate Template Engine to HCL2 | Implemented | 2026-05-07 | Donald Gifford | [0003-migrate-template-engine-to-hcl2.md](0003-migrate-template-engine-to-hcl2.md) |
 | DESIGN-0004 | Unify Config File Format After HCL2 Cutover | Implemented | 2026-05-12 | Donald Gifford | [0004-unify-config-file-format-after-hcl2-cutover.md](0004-unify-config-file-format-after-hcl2-cutover.md) |
 | DESIGN-0005 | Variable input via vars file | Draft | 2026-05-18 | Donald Gifford | [0005-variable-input-via-vars-file.md](0005-variable-input-via-vars-file.md) |
+| DESIGN-0006 | object and collection variable types | Draft | 2026-06-29 | Donald Gifford | [0006-object-and-collection-variable-types.md](0006-object-and-collection-variable-types.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/impl/0006-migrate-lockfile-from-yaml-to-hcl.md
+++ b/docs/impl/0006-migrate-lockfile-from-yaml-to-hcl.md
@@ -76,9 +76,10 @@ mechanical format migration; the rationale lives entirely in the
   pin forge to v0.4.x.
 - Lockfile schema changes — fields stay the same; only the
   serialisation format changes.
-- Object/list/map variable support — covered by RFC-0002. The HCL
-  lockfile naturally extends to nested values when those types land,
-  but the cutover here is single-format-swap only.
+- Object/list/map variable support — covered by RFC-0002 (designed
+  in DESIGN-0006). The HCL lockfile naturally extends to nested
+  values when those types land, but the cutover here is
+  single-format-swap only.
 - Backwards-compatible dual-format reader after the cutover.
   v0.5.x rejects YAML lockfiles outright and points the user at
   `docs/MIGRATION.md`.

--- a/docs/impl/0008-variable-input-via-vars-file.md
+++ b/docs/impl/0008-variable-input-via-vars-file.md
@@ -110,8 +110,9 @@ existing resolution flow that already terminates in
 - **HCL function calls inside vars files** (OQ-1) — strict
   literals only.
 - **Object / list / map values.** This IMPL ships with scalar-only
-  parsing; the parser is structured so RFC-0002's types drop in via
-  the existing `cty.Value` plumbing without re-architecting.
+  parsing; the parser is structured so RFC-0002's types
+  (designed in DESIGN-0006) drop in via the existing `cty.Value`
+  plumbing without re-architecting.
 - **`--strict-vars` flag** to promote unknown-key warnings to
   errors (OQ-7) — not in v1.
 - **Recording the vars file path in the lockfile** (DESIGN-0005
@@ -681,9 +682,10 @@ actionable (DESIGN-0005-aligned), rather than Cobra's generic
 - **External libraries** (`hashicorp/hcl/v2`, `zclconf/go-cty`) are
   already in `go.mod` — no new dependencies.
 - **Composes with future work:**
-  - **RFC-0002** (object/list/map types) — when those types land,
-    the vars-file parser's existing `cty.Value` plumbing extends to
-    nested HCL natively. No change to the package public API.
+  - **RFC-0002** (object/list/map types, designed in DESIGN-0006)
+    — when those types land, the vars-file parser's existing
+    `cty.Value` plumbing extends to nested HCL natively. No change
+    to the package public API.
   - **IMPL-0006** (HCL lockfile) — both files become HCL2; the
     parser/emitter machinery is shared.
   - **RFC-0003** (locals + namespacing) — vars-file keys remain
@@ -765,6 +767,7 @@ actionable (DESIGN-0005-aligned), rather than Cobra's generic
 
 - [DESIGN-0005 — Variable input via vars file](../design/0005-variable-input-via-vars-file.md) — the design this IMPL realises.
 - [RFC-0002 — Object and collection variable types](../rfc/0002-object-and-collection-variable-types.md) — composing feature (object/list/map values in vars files).
+- [DESIGN-0006 — Object and collection variable types](../design/0006-object-and-collection-variable-types.md) — RFC-0002's design; its `--var-file` section relies on this IMPL's parser shape extending via `cty.Convert` for structured types.
 - [RFC-0003 — Locals for derived values](../rfc/0003-locals-for-derived-values.md) — namespacing convention (vars files keep bare keys, RFC-0003 affects templates/conditions only).
 - [IMPL-0006 — Migrate lockfile from YAML to HCL](0006-migrate-lockfile-from-yaml-to-hcl.md) — sibling HCL2 work; shares parsing patterns.
 - `internal/config/loader_hcl.go` — HCL2 parsing reference pattern (lines 69–74).

--- a/docs/impl/0009-object-and-collection-variable-types.md
+++ b/docs/impl/0009-object-and-collection-variable-types.md
@@ -1,0 +1,1002 @@
+---
+id: IMPL-0009
+title: "object and collection variable types"
+status: Draft
+author: Donald Gifford
+created: 2026-06-29
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# IMPL 0009: object and collection variable types
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-06-29
+
+<!--toc:start-->
+- [Objective](#objective)
+- [Scope](#scope)
+  - [In Scope](#in-scope)
+  - [Out of Scope](#out-of-scope)
+- [Implementation Phases](#implementation-phases)
+  - [Phase A: type expression parser](#phase-a-type-expression-parser)
+  - [Phase B: variable struct + HCL schema refactor](#phase-b-variable-struct--hcl-schema-refactor)
+  - [Phase C: default expression + validation evaluation](#phase-c-default-expression--validation-evaluation)
+  - [Phase D: input integration (vars-file + --set)](#phase-d-input-integration-vars-file----set)
+  - [Phase E: prompt UX](#phase-e-prompt-ux)
+  - [Phase F: lockfile + template integration](#phase-f-lockfile--template-integration)
+  - [Phase G: documentation + release prep](#phase-g-documentation--release-prep)
+- [File Changes](#file-changes)
+- [Testing Plan](#testing-plan)
+- [Quality Gates](#quality-gates)
+- [Dependencies](#dependencies)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Objective
+
+Implement [DESIGN-0006 — Object and collection variable
+types](../design/0006-object-and-collection-variable-types.md): add
+`object({…})`, `list(T)`, and `map(T)` to the variable type surface,
+replace the bespoke `choice` type with a Terraform-style
+`validation { … }` block, and emit a deprecation warning for the
+`int` type alias. Ships as v0.7.0 alongside RFC-0003 (locals + `var.*`
+namespacing) per DESIGN-0006 OQ-1.
+
+**Implements:** [DESIGN-0006](../design/0006-object-and-collection-variable-types.md).
+
+## Scope
+
+### In Scope
+
+- New `internal/config/vartype.go` that parses a `variable.type` HCL
+  expression to a `cty.Type` via `hashicorp/hcl/v2/ext/typeexpr`
+  (DESIGN-0006 OQ-2).
+- Variable struct refactor in `internal/config/blueprint.go`:
+  `Type string` → `Type cty.Type` + `TypeSource string`;
+  `Default string` → `DefaultExpr hcl.Expression` + `DefaultSource string`;
+  `Validations []Validation` (new); remove `Validate` and `Choices`
+  fields.
+- HCL schema refactor in `internal/config/hcldec_spec.go` and the
+  hand-decode helpers in `internal/config/loader_hcl.go`:
+  - new `validation { condition, error_message }` repeatable nested
+    block on `variable`
+  - load-time rejection of legacy `choices = [...]` and
+    `validate = "regex"` fields with errors pointing at MIGRATION.md
+  - `default` and `type` captured as raw HCL expressions, not
+    string literals
+- Default-expression evaluation against the resolved variable scope
+  (replacing the current prompt-time string-render).
+- Validation-block evaluation against the resolved variable scope
+  (cross-variable references allowed per DESIGN-0006 OQ-4).
+- `int` deprecation warning at `LoadBlueprint` time (DESIGN-0006
+  OQ-6).
+- Vars-file structured-value support — `internal/varsfile` delegates
+  to `cty.Convert` against the declared `cty.Type`; existing
+  scalar-only test corpus extends with object/list/map fixtures.
+- `--set` extensions: top-level object replacement via HCL literal
+  parsing; list/map `--set` rejected with an actionable error.
+- Prompt UX: object unfold to per-field prompts in declaration
+  order; list/map required-and-unsupplied error with copy-pasteable
+  vars-file snippet.
+- Lockfile cty machinery (`internal/lockfile/cty.go`) extended for
+  structured types; HCL emitter (`internal/lockfile/emit_hcl.go`)
+  round-trip verification.
+- Template strict-vars (`internal/template`) updated to allow nested
+  attribute access against declared object types.
+- Documentation: MIGRATION.md v0.7 section; REFERENCE.md updated;
+  CLAUDE.md updated; v0.7.0 release notes.
+
+### Out of Scope
+
+- `tuple([…])`, `set(T)`, optional object fields, `null` values.
+- Interactive TUI widget for list/map input — the documented
+  trade-off per DESIGN-0006 is the "use --var-file" error path.
+- `prompt { kind = "select", options = [...] }` block to re-introduce
+  the legacy `choice` type's select-list UX. Tracked as a follow-up
+  RFC (DESIGN-0006 OQ-5).
+- In-tool migrator for `choice` / `choices` / scalar-only `validate`
+  fields — load-time errors point at MIGRATION.md per ADR-0002.
+- `locals { … }` block — covered by RFC-0003 / its own IMPL doc.
+  This IMPL coordinates the `var.*` namespace flip but does not
+  implement locals.
+- `error_message` template interpolation (DESIGN-0006 OQ-3 — static
+  string only in v1).
+- Promoting the `int` deprecation warning to a load-time error
+  (DESIGN-0006 OQ-6 — explicit non-commitment for this release).
+- JSON Schema export of the new variable type surface for IDE
+  integration (out of band; would be its own IMPL).
+
+## Implementation Phases
+
+Seven phases. Phases A–C are the schema-side change. Phase D is the
+input-side change. Phase E is prompt UX. Phase F closes the loop on
+downstream consumers (lockfile + templates). Phase G ships docs.
+
+Phases A and B together are the minimum to get the new schema
+loading; from there each phase brings up one consumer surface.
+
+> **Sequencing with RFC-0003 (locals + `var.*` namespacing).**
+> Per DESIGN-0006 OQ-1, both ship in v0.7.0. The IMPL question of
+> *which order* the two parallel streams complete is OQ-1 below.
+> Tentative assumption: this IMPL's Phase A starts independently;
+> Phases C and F coordinate with RFC-0003's IMPL on the `var.*`
+> scope and template-strict-vars changes.
+
+---
+
+### Phase A: type expression parser
+
+Stand up the cty type expression parser as a self-contained module
+that any other code path can consume. Foundational; everything else
+depends on this.
+
+#### Tasks
+
+- [ ] **A.1 Create the new file.**
+  - File: `internal/config/vartype.go` (new).
+  - Package comment summarises responsibility: "parses a
+    `variable.type` HCL expression to a `cty.Type` using the cty
+    type-expression grammar, plus forge-specific error wrapping and
+    the `int` deprecation warning."
+
+- [ ] **A.2 Define the public API.**
+  - File: `internal/config/vartype.go` (modify).
+  - Signature:
+
+    ```go
+    // ParseVariableType resolves the variable's `type` HCL
+    // expression to a cty.Type. Accepts bareword scalars
+    // (string, bool, number, int), the legacy quoted-string
+    // forms during the v0.7 transition, and the cty constructor
+    // forms (object({...}), list(T), map(T)). Returns a non-nil
+    // diagnostic when the expression is malformed or names an
+    // unsupported type form (tuple, set, optional).
+    //
+    // deprecation, when non-nil, indicates the author used a
+    // deprecated form (today: `type = int` or `type = "int"`)
+    // that still resolves but should migrate to `type = number`.
+    // Callers surface the deprecation through ui.Warning.
+    func ParseVariableType(expr hcl.Expression) (
+        ty          cty.Type,
+        deprecation *Deprecation,
+        diags       hcl.Diagnostics,
+    )
+
+    type Deprecation struct {
+        Variable string
+        Range    hcl.Range
+        Message  string
+    }
+    ```
+
+- [ ] **A.3 Implement using `hashicorp/hcl/v2/ext/typeexpr`.**
+  - Delegate the parse to `typeexpr.Type(expr)`.
+  - On success, inspect for `cty.Tuple`, `cty.Set`, or types with
+    optional attributes; if present, return a forge-specific
+    diagnostic pointing at the supported type table in
+    REFERENCE.md.
+  - On failure, wrap the diagnostic to include the variable name
+    (caller passes it via a separate parameter or via expression
+    range lookup).
+
+- [ ] **A.4 Implement the `int` deprecation detection.**
+  - Inspect the expression source: if it parses as either the bare
+    `int` keyword or the quoted-string `"int"`, set
+    `deprecation = &Deprecation{...}` with the message
+    `'type = int' is deprecated; use 'type = number' instead`.
+  - The Range carries the source location of the `type` attribute
+    so the warning surfaces with file:line:col.
+
+- [ ] **A.5 Hermetic test fixtures.**
+  - Directory: `internal/config/testdata/vartype/` (new).
+  - Per-fixture pattern: each fixture is a `.hcl` snippet with one
+    variable declaration. Fixture covers the form being tested
+    (e.g. `accepts-list-string.hcl`, `rejects-tuple.hcl`,
+    `int-deprecation.hcl`).
+
+- [ ] **A.6 Unit tests.**
+  - File: `internal/config/vartype_test.go` (new).
+  - Table-driven coverage for:
+    - All accepted bareword forms: `string`, `bool`, `number`,
+      `int`, `list(string)`, `list(number)`, `map(string)`,
+      `object({k = string})`, nested object
+      `object({addr = object({host = string, port = number})})`.
+    - Legacy quoted-string forms: `"string"`, `"bool"`, `"int"`.
+    - `"choice"` form is **not** accepted — clean error pointing
+      at MIGRATION.md (DESIGN-0006 [Validation block](../design/0006-object-and-collection-variable-types.md#validation-block-choice-replacement)).
+    - Rejected forms: `tuple([string, number])`, `set(string)`,
+      `object({k = optional(string)})` — each with a clean error.
+    - `int` deprecation: assert `Deprecation` is non-nil for
+      `int` and `"int"`, nil for `number` and `string`.
+  - Coverage gate: ≥90%.
+
+- [ ] **A.7 Run `make lint` and `make fmt`.**
+
+#### Success Criteria
+
+- `ParseVariableType` is the single source of truth for converting
+  a `type` expression to a `cty.Type`.
+- All accepted forms round-trip cleanly; all rejected forms produce
+  errors with file:line:col and a migration pointer.
+- `int` deprecation reliably detected and surfaced via
+  `Deprecation`.
+- `make ci` green on `internal/config/`.
+
+---
+
+### Phase B: variable struct + HCL schema refactor
+
+Land the Go-side type changes and the HCL schema updates so
+`LoadBlueprint` can parse the new shape. No evaluation logic yet —
+that's Phase C.
+
+#### Tasks
+
+- [ ] **B.1 Refactor `Variable` struct.**
+  - File: `internal/config/blueprint.go` (modify).
+  - Before/after:
+
+    ```go
+    // Before
+    type Variable struct {
+        Name        string
+        Description string
+        Type        string
+        Default     string
+        Required    bool
+        Validate    string
+        Choices     []string
+    }
+
+    // After
+    type Variable struct {
+        Name          string
+        Description   string
+        Type          cty.Type
+        TypeSource    string
+        DefaultExpr   hcl.Expression
+        DefaultSource string
+        Required      bool
+        Validations   []Validation
+    }
+
+    type Validation struct {
+        Condition    hcl.Expression
+        ErrorMessage string
+        DefRange     hcl.Range
+    }
+    ```
+  - Add field comments explaining that `Type` / `DefaultExpr` are
+    captured-at-load-time and mirror `Condition.When`'s pattern.
+
+- [ ] **B.2 Update HCL schema (eager spec).**
+  - File: `internal/config/hcldec_spec.go` (modify).
+  - The `variable "name" { … }` block stays hand-decoded (per the
+    file's existing comment) — extend `variableBlockBodySchema` to:
+    - allow the `validation { … }` repeatable nested block
+    - remove the `choices` and `validate` attributes from the
+      accepted set (so they fall through to a custom rejection
+      diagnostic in the hand-decoder, not a generic "unknown
+      attribute" error)
+
+- [ ] **B.3 Implement validation-block schema.**
+  - File: `internal/config/hcldec_spec.go` (modify) — add a new
+    `validationBlockBodySchema`:
+
+    ```go
+    var validationBlockBodySchema = &hcl.BodySchema{
+        Attributes: []hcl.AttributeSchema{
+            {Name: "condition",     Required: true},
+            {Name: "error_message", Required: true},
+        },
+    }
+    ```
+
+- [ ] **B.4 Update the loader hand-decoder.**
+  - File: `internal/config/loader_hcl.go` (modify).
+  - For each `variable` block:
+    - call `ParseVariableType(typeAttr.Expr)` → `Variable.Type`
+    - capture `default` as `hcl.Expression` (don't evaluate)
+    - decode any nested `validation { … }` blocks into
+      `Variable.Validations`
+    - reject `choices = [...]` and `validate = "regex"` with the
+      MIGRATION.md-pointed error
+    - surface the deprecation from `ParseVariableType` via
+      `Deprecations []Deprecation` on the load result
+      (so callers can warn)
+
+- [ ] **B.5 Update `ValidateBlueprint`.**
+  - File: `internal/config/validate.go` (modify).
+  - Remove the `validVariableTypes` map and the per-variable
+    `Type` allow-list check — typing is now enforced by
+    `ParseVariableType`.
+  - Remove the `choices` and `validate` validations (the fields
+    are gone).
+  - Keep the sync-strategy and managed-files validations
+    unchanged.
+
+- [ ] **B.6 Plumb deprecations to the load callers.**
+  - File: `internal/config/loader.go` (modify),
+    `cmd/create.go`, `cmd/sync.go` (modify).
+  - Each call site that does `config.LoadBlueprint(...)` reads the
+    returned `Deprecations` and surfaces them via `ui.Warningf`
+    before proceeding. Pattern mirrors how IMPL-0008 surfaces
+    `UnknownVarsFileKeys`.
+
+- [ ] **B.7 Test corpus update.**
+  - Update existing `internal/config/testdata/` fixtures: any that
+    use `type = "choice"`, `choices = [...]`, or
+    `validate = "regex"` get rewritten to use the new validation
+    block (or split into separate "legacy-reject" fixtures
+    asserting the rejection error).
+  - New fixtures covering the validation block: single, multiple
+    stacked, validation referencing an object field.
+
+- [ ] **B.8 Unit + integration tests.**
+  - File: `internal/config/loader_hcl_test.go` (modify),
+    `internal/config/validate_test.go` (modify).
+  - Tests:
+    - Loading a blueprint with the new schema (each type, each
+      validation form) produces the expected `Variable` shape.
+    - Loading a legacy `choices = [...]` produces a clean error
+      with MIGRATION.md pointer.
+    - Loading a legacy scalar `validate = "regex"` produces a
+      clean error with MIGRATION.md pointer.
+    - `int` deprecation flows through to the `Deprecations` slice.
+    - `ValidateBlueprint` no longer rejects `object`/`list`/`map`
+      types (the type check is gone, leaving only sync-strategy
+      and managed-files validations).
+
+- [ ] **B.9 Run `make ci`.**
+
+#### Success Criteria
+
+- `LoadBlueprint` parses the new schema cleanly: object / list /
+  map types, validation block, and the `int` deprecation warning.
+- Legacy `choices` and `validate` fields produce load-time errors
+  that point at MIGRATION.md.
+- All existing blueprint fixtures pass after the migration
+  rewrite.
+- `make ci` green.
+
+---
+
+### Phase C: default expression + validation evaluation
+
+Wire the new `DefaultExpr` and `Validations` fields into the
+variable resolution flow. This is where the value pipeline actually
+becomes structured-type-aware.
+
+#### Tasks
+
+- [ ] **C.1 Default-expression evaluation.**
+  - File: `internal/prompt/prompt.go` (modify),
+    `internal/create/create.go` (modify).
+  - Replace the current "render default string via the template
+    engine" path with "evaluate `DefaultExpr` against the
+    already-bound `var.*` scope":
+
+    ```go
+    val, diags := v.DefaultExpr.Value(&hcl.EvalContext{
+        Variables: map[string]cty.Value{"var": cty.ObjectVal(bound)},
+    })
+    ```
+  - Coerce the result against `Variable.Type` via `cty.Convert`;
+    surface mismatches with file:line:col from
+    `DefaultExpr.Range()`.
+  - Keep the prompt-time fallback for the v0.7 backwards-compat
+    shim: if `Type` is `string`/`bool`/`number` and the default
+    parses as a literal string, the template-render path remains
+    accessible during the transition window.
+
+- [ ] **C.2 Build the resolved-variable scope.**
+  - File: `internal/create/create.go` (modify) or new helper
+    `internal/create/scope.go` (new).
+  - Helper that walks `bp.Variables` in declaration order and
+    builds the `cty.Value` scope incrementally so each variable's
+    default / validation can reference earlier ones. Mirrors the
+    variable-resolution ordering already implicit in
+    `prompt.CollectVariables`.
+
+- [ ] **C.3 Validation-block evaluation.**
+  - File: `internal/create/create.go` or new
+    `internal/config/validation.go` (decide per OQ-2 below).
+  - After all variables are resolved, iterate every variable's
+    `Validations`. For each:
+    - evaluate `Condition` against the full resolved scope
+    - if the result is not `cty.True`, accumulate an error
+      formatted as
+      `<error_message> (variable "X", blueprint.hcl:L:C)`
+  - If any validation fails, abort the create/sync flow before any
+    files are touched. Validation failures stack — surface all of
+    them, not just the first.
+
+- [ ] **C.4 Cross-variable scope tests.**
+  - Verify a `validation { condition = var.a != var.b, … }` on
+    variable `c` sees both `a` and `b` in scope (DESIGN-0006 OQ-4
+    decision).
+  - Verify a default that references a later-declared variable
+    errors cleanly (forward references not allowed).
+
+- [ ] **C.5 Error-surfacing tests.**
+  - Single validation failure surfaces verbatim error_message.
+  - Multiple stacked validation failures all surface (not
+    short-circuited).
+  - Default-expression type mismatch surfaces with
+    `blueprint.hcl:L:C` pointing at the `default` attribute.
+
+- [ ] **C.6 Run `make ci`.**
+
+#### Success Criteria
+
+- Defaults evaluate as HCL expressions against the resolved
+  variable scope; backwards-compat shim works for legacy
+  scalar-string defaults.
+- Validation blocks evaluate after resolution; failures abort the
+  flow cleanly with the documented error format.
+- Cross-variable references in defaults and validation conditions
+  work as designed.
+- `make ci` green.
+
+---
+
+### Phase D: input integration (vars-file + --set)
+
+Extend the CLI input paths so users can supply structured values.
+Vars-file is mostly free (cty.Convert handles structured values
+natively); `--set` gets a narrow extension for object literals.
+
+#### Tasks
+
+- [ ] **D.1 Vars-file structured-type support.**
+  - File: `internal/varsfile/varsfile.go` (modify).
+  - `coerceToDeclared` (existing helper) already delegates to
+    `cty.Convert`. Verify it handles object/list/map targets
+    cleanly — the only adjustment may be to `ctyTypeForDeclared`,
+    which today maps a *string* tag to `cty.Type`. Update it to
+    consume a `cty.Type` directly (the type field is now
+    `cty.Type` on the `Variable` struct):
+
+    ```go
+    // Before (string tag → cty.Type)
+    func ctyTypeForDeclared(tag string) cty.Type
+
+    // After (caller passes cty.Type directly)
+    // (helper becomes unnecessary; replace with direct
+    //  v.Type field access)
+    ```
+
+- [ ] **D.2 Vars-file test corpus extension.**
+  - Directory: `internal/varsfile/testdata/object-types/` (new).
+  - Fixtures: `object-flat.forge-vars.hcl`,
+    `object-nested.forge-vars.hcl`,
+    `list-of-numbers.forge-vars.hcl`,
+    `map-of-strings.forge-vars.hcl`, plus mismatched-type
+    fixtures for each shape.
+
+- [ ] **D.3 Vars-file integration tests.**
+  - File: `internal/varsfile/varsfile_test.go` (modify).
+  - Each fixture: assert `Load` returns the expected
+    `map[string]cty.Value`; mismatched-type cases assert clean
+    error with `vars file PATH:L:C` location.
+
+- [ ] **D.4 `--set` object literal parsing.**
+  - File: `cmd/create.go` (modify),
+    `internal/create/setvars.go` (likely new helper).
+  - When the value side of a `--set k=v` is detected as an HCL
+    object literal (starts with `{`), parse it through `hclparse`
+    against an empty EvalContext and coerce against the declared
+    type:
+
+    ```sh
+    forge create go/api --set 'git_provider={repo_type="github",repo_url="github.com",project_org="me"}'
+    ```
+  - Scalars continue to flow through the existing string-coercion
+    path (no change).
+
+- [ ] **D.5 `--set` list/map rejection.**
+  - File: `cmd/create.go` (modify).
+  - At resolve time, after the user supplies `--set X=Y` for a
+    variable `X` declared as `list(T)` or `map(T)`, surface:
+
+    ```
+    --set on variable X (list(...)) is not supported;
+    use --var-file to supply list and map values.
+    ```
+
+- [ ] **D.6 Integration tests for create.**
+  - File: `internal/create/varsfile_integration_test.go` (modify) /
+    a new `objectset_integration_test.go`.
+  - Tests:
+    - `--var-file` supplies a nested object; scaffold succeeds and
+      the lockfile records the nested value.
+    - `--set` with an object literal succeeds; lockfile records the
+      object.
+    - `--set` against a `list(T)` variable errors with the
+      documented message.
+
+- [ ] **D.7 Run `make ci`.**
+
+#### Success Criteria
+
+- A vars file with object / list / map / nested-object values
+  loads cleanly; mismatched types abort before any files are
+  touched.
+- `--set` accepts top-level object replacement via HCL literal.
+- `--set` against list/map errors with the documented message
+  pointing at `--var-file`.
+- `make ci` green.
+
+---
+
+### Phase E: prompt UX
+
+The interactive flow. Objects unfold to per-field prompts; lists
+and maps are explicit non-interactive.
+
+#### Tasks
+
+- [ ] **E.1 Object-unfold prompt logic.**
+  - File: `internal/prompt/prompt.go` (modify).
+  - For each variable whose declared type is `cty.Object(...)`:
+    - iterate attribute names in declaration order (preserve via
+      `cty.Type.AttributeTypes()` plus a parallel ordered slice
+      captured at parse time)
+    - prompt for each field with a dotted label
+      (`git_provider.repo_type`)
+    - default values come from evaluating the object default
+      against the resolved scope, then projecting per field
+    - reconstruct the resolved value as
+      `cty.ObjectVal(map[string]cty.Value{...})` before binding
+      to the scope
+  - Nested objects unfold recursively.
+  - Lists/maps inside an object follow the same non-interactive
+    rule as top-level lists/maps (E.2).
+
+- [ ] **E.2 List/map non-interactive error.**
+  - File: `internal/prompt/prompt.go` (modify).
+  - If a variable is `list(T)` or `map(T)`, is required, and has
+    no value supplied (no vars-file, no `--set` — which would have
+    errored at D.5 anyway, no default), error with a
+    copy-pasteable vars-file snippet:
+
+    ```text
+    Error: variable "exposed_ports" (list(number)) is required but
+    cannot be supplied interactively.
+
+    Provide it via --var-file:
+
+        # project.forge-vars.hcl
+        exposed_ports = [8080, 9090]
+
+        forge create ... --var-file ./project.forge-vars.hcl
+    ```
+
+- [ ] **E.3 Declaration-order preservation.**
+  - File: `internal/config/blueprint.go` and the loader (modify
+    if needed).
+  - `cty.Object(...)`'s attribute map is unordered. Add a parallel
+    `[]string` of attribute names on the `Variable` struct (e.g.
+    `TypeFieldOrder []string`) captured at load time so the prompt
+    flow can iterate fields in author-declared order.
+
+- [ ] **E.4 Prompt-flow integration tests.**
+  - File: `internal/prompt/prompt_test.go` (modify).
+  - Tests:
+    - Object unfold prompts for each field in declaration order.
+    - Nested object unfolds recursively.
+    - Required list errors with the documented snippet.
+    - Required map errors with the documented snippet.
+    - List/map with a default and no override flows silently
+      (no prompt, no error).
+    - Object with a derived default (`default = var.X == "..." ? {...} : {...}`)
+      pre-fills per-field prompts correctly.
+
+- [ ] **E.5 Run `make ci`.**
+
+#### Success Criteria
+
+- Interactive `forge create` against a blueprint with an object
+  variable produces per-field prompts in declaration order; the
+  resolved value reconstructs as a single `cty.Value`.
+- Required list/map without input fails fast with the documented
+  copy-pasteable error.
+- Existing scalar prompt UX is unchanged.
+- `make ci` green.
+
+---
+
+### Phase F: lockfile + template integration
+
+Downstream consumers. Both are nearly free — the value pipeline is
+already `cty.Value`-native — but they need explicit verification
+under structured-type round-trip.
+
+#### Tasks
+
+- [ ] **F.1 Lockfile `cty` helpers.**
+  - File: `internal/lockfile/cty.go` (modify).
+  - `ToCtyValues` / `FromCtyValues` already operate on
+    `cty.Value`. The type-aware coercion in `ToCtyValues` switches
+    on declared variable type tag (string/bool/int). Replace the
+    tag-switch with a single `cty.Convert(val, declaredType)` —
+    same approach as `internal/varsfile`.
+
+- [ ] **F.2 Lockfile HCL round-trip verification.**
+  - File: `internal/lockfile/emit_hcl.go` and
+    `internal/lockfile/loader_hcl.go` (modify if needed).
+  - `hclwrite` natively emits nested values; the loader already
+    pulls the `variables { ... }` block via hand-decode. Verify
+    end-to-end with a structured-type fixture; adjust the emitter
+    only if `hclwrite` produces something the loader can't parse
+    back.
+
+- [ ] **F.3 Lockfile round-trip tests.**
+  - File: `internal/lockfile/roundtrip_test.go` (modify) or new
+    `internal/lockfile/object_roundtrip_test.go`.
+  - Fixture: a project lockfile with `variables { ... }` carrying
+    an object, a list, a map, and a nested object. Assert
+    write-then-load yields byte-identity (or at minimum a
+    semantically equal `*Lockfile`).
+
+- [ ] **F.4 Template strict-vars update.**
+  - File: `internal/template/renderer.go` (modify) — wherever the
+    strict-vars check lives.
+  - Allow nested attribute access against declared object types:
+    `var.git_provider.repo_type` is legal iff `git_provider` is
+    declared as `object({repo_type = …, …})` and `repo_type` is a
+    declared field.
+  - Allow index access against declared `list(T)` and `map(T)`
+    types: `var.exposed_ports[0]`, `var.build_targets["linux"]`.
+  - Coordinate with RFC-0003's IMPL on the `var.*` scope —
+    DESIGN-0006 assumes that namespace lands first or co-lands
+    (see OQ-1 below).
+
+- [ ] **F.5 Template integration tests.**
+  - File: `internal/template/renderer_test.go` (modify).
+  - Tests:
+    - `${var.obj.field}` renders correctly against an
+      object-typed variable.
+    - `${var.list[0]}` renders correctly against a list-typed
+      variable.
+    - `${var.map["key"]}` renders correctly against a map-typed
+      variable.
+    - `${var.obj.undeclared_field}` errors with strict-vars
+      diagnostic.
+    - `%{ for x in var.list ~}...%{ endfor ~}` iterates as
+      expected.
+
+- [ ] **F.6 Run `make ci`.**
+
+#### Success Criteria
+
+- Lockfile written from a project with object/list/map variables
+  round-trips through load cleanly.
+- Templates can access nested values via attribute / index syntax;
+  strict-vars validation handles the new shapes.
+- `forge sync` and `forge check` operate on the new value shapes
+  without code changes (verified via integration tests reusing
+  the F.3 lockfile fixture).
+- `make ci` green.
+
+---
+
+### Phase G: documentation + release prep
+
+#### Tasks
+
+- [ ] **G.1 MIGRATION.md update.**
+  - File: `docs/MIGRATION.md` (modify).
+  - New section: "Variable type system upgrade (v0.7+)" with
+    before/after snippets for:
+    - `type = "choice"` + `choices` → `type = string` + `validation { condition = contains(...) }`
+    - `validate = "regex"` → `validation { condition = can(regex(...)) }`
+    - `type = int` → `type = number` (note: warning only, not
+      breaking — works either way)
+  - Add a "Variable type expressiveness gain" sub-section showing
+    the renovate-config use case collapsing from 4 scalar
+    variables to 1 object variable.
+
+- [ ] **G.2 REFERENCE.md update.**
+  - File: `docs/REFERENCE.md` (modify).
+  - Variable types table gains `object({…})`, `list(T)`, `map(T)`
+    rows.
+  - `validate` and `choices` rows removed; new "validation block"
+    section after the variable table.
+  - `int` row gets a deprecation footnote.
+  - Source-of-truth table gains `internal/config/vartype.go`.
+
+- [ ] **G.3 CLAUDE.md update.**
+  - File: `CLAUDE.md` (modify).
+  - Architecture entry for the new `internal/config/vartype.go`
+    helper.
+  - CLI Design Decisions update: choice→validation reframing,
+    object/list/map type surface, `int` deprecation.
+
+- [ ] **G.4 v0.7.0 release notes.**
+  - File: `docs/release-notes/v0.7.0-object-types.md` (new).
+  - Highlight the additive features (object/list/map types) and
+    the breaking changes (choice/choices/validate removal,
+    prompt-UX regression for `choice`-style enums). Walk the
+    reader through the migration with the same snippets as
+    MIGRATION.md.
+  - Cross-reference RFC-0003's IMPL doc if it ships in the same
+    release.
+
+- [ ] **G.5 forge-registry follow-up.**
+  - Not in this repo. File an issue against
+    `github.com/donaldgifford/forge-registry` to update the
+    renovate-config blueprint to use the new `git_provider`
+    object variable. Note as out-of-repo in the IMPL doc
+    closing checklist.
+
+- [ ] **G.6 docz-reviewer pass.**
+  - Run the docz-reviewer agent against the new MIGRATION.md
+    section, REFERENCE.md updates, and release notes.
+
+- [ ] **G.7 Run `make ci`.**
+
+#### Success Criteria
+
+- MIGRATION.md, REFERENCE.md, CLAUDE.md, and v0.7.0 release
+  notes are merged and self-consistent.
+- forge-registry follow-up issue filed.
+- docz-reviewer pass complete with findings addressed.
+- `make ci` green.
+
+---
+
+## File Changes
+
+### New files
+
+| Path | Purpose |
+|---|---|
+| `internal/config/vartype.go` | Type expression parser + `int` deprecation detection. |
+| `internal/config/vartype_test.go` | Parser tests. |
+| `internal/config/testdata/vartype/` | Per-form fixtures. |
+| `internal/create/scope.go` (if extracted) | Resolved-variable scope builder. |
+| `internal/create/setvars.go` (if extracted) | `--set` HCL-literal parser. |
+| `internal/create/objectset_integration_test.go` | `--set` object literal integration tests. |
+| `internal/varsfile/testdata/object-types/` | Structured-type fixtures. |
+| `internal/lockfile/object_roundtrip_test.go` | Structured-type lockfile round-trip. |
+| `docs/release-notes/v0.7.0-object-types.md` | Release notes. |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `internal/config/blueprint.go` | Variable struct refactor: `Type cty.Type`, `DefaultExpr hcl.Expression`, `Validations []Validation`, remove `Validate`/`Choices`. |
+| `internal/config/hcldec_spec.go` | New `validation` block schema; `variableBlockBodySchema` updates. |
+| `internal/config/loader_hcl.go` | Hand-decode the new variable shape; reject legacy `choices`/`validate`; surface `int` deprecation. |
+| `internal/config/loader.go` | Plumb deprecations through. |
+| `internal/config/validate.go` | Remove `validVariableTypes` map and `choice`-specific validations. |
+| `internal/config/testdata/` | Migrate existing legacy fixtures; add new ones. |
+| `internal/prompt/prompt.go` | Object unfold; list/map non-interactive error; default eval via HCL expression. |
+| `internal/prompt/prompt_test.go` | Add object / list / map cases. |
+| `internal/create/create.go` | Resolved-scope build; validation-block evaluation. |
+| `internal/varsfile/varsfile.go` | Drop the `string → cty.Type` helper; coerce against `Variable.Type` directly. |
+| `internal/varsfile/varsfile_test.go` | Structured-type tests. |
+| `internal/lockfile/cty.go` | Drop the tag-switch coercion; single `cty.Convert` path. |
+| `internal/lockfile/emit_hcl.go` / `loader_hcl.go` | Verify round-trip; adjust if needed. |
+| `internal/template/renderer.go` | Strict-vars accepts nested attribute / index access. |
+| `cmd/create.go`, `cmd/sync.go` | Surface deprecations via `ui.Warningf`; `--set` HCL literal parsing; list/map rejection. |
+| `docs/MIGRATION.md` | New v0.7 section. |
+| `docs/REFERENCE.md` | Variable types table updates, validation block section. |
+| `CLAUDE.md` | Architecture + design-decision updates. |
+
+## Testing Plan
+
+- **Unit tests** at each layer: `vartype` parser, validation
+  evaluation, vars-file coercion, lockfile cty helpers, template
+  strict-vars.
+- **Integration tests** scaffolding a fixture blueprint with the
+  full type surface (one object, one list, one map, plus a scalar
+  with a validation block):
+  - `forge create` via vars-file
+  - `forge create` via `--set` (scalar + object literal)
+  - `forge create` interactive (object unfold, list/map error)
+  - `forge sync` after a vars-file change to an object field
+  - `forge check` against a project with structured-type variables
+- **End-to-end** smoke test against the forge-registry
+  renovate-config blueprint once it adopts the new `git_provider`
+  object variable (G.5 follow-up).
+- **Coverage gate:** ≥85% on the new code paths (matches IMPL-0008's
+  bar).
+- **Regression coverage:** existing IMPL-0008 vars-file tests must
+  continue to pass with no modifications (the parser change is
+  transparent for scalar-only fixtures).
+
+## Quality Gates
+
+- **After Phase A:** `make ci` green; coverage on
+  `internal/config/vartype.go` ≥90%.
+- **After Phase B:** `make ci` green; every existing
+  `internal/config/testdata/` blueprint either loads under the new
+  schema or has been migrated to the new shape with a clear
+  reason in the commit.
+- **After Phase C:** `make ci` green; a fixture blueprint with
+  cross-variable validations exercises the resolved-scope path.
+- **After Phase D:** `make ci` green; vars-file structured-type
+  coverage matches the scalar-type coverage from IMPL-0008.
+- **After Phase E:** `make ci` green; manual smoke test in a real
+  terminal verifying the object-unfold prompt UX (huh has some
+  layout quirks the headless tests won't catch).
+- **After Phase F:** `make ci` green; lockfile round-trip is
+  byte-identical for structured-type fixtures.
+- **After Phase G:** `make ci` green; `mkdocs build` succeeds with
+  the new docs.
+
+## Dependencies
+
+- **`hashicorp/hcl/v2/ext/typeexpr`** — already in the module
+  dependency tree as a transitive dep of `hashicorp/hcl/v2`. No
+  new top-level dep.
+- **`zclconf/go-cty`** — already in use; this IMPL leans on
+  `cty.Convert`, `cty.Object`, `cty.List`, `cty.Map` constructors.
+- **IMPL-0006 (HCL lockfile)** — already shipped. Hard prerequisite
+  for clean structured-type round-trip.
+- **IMPL-0008 (vars-file)** — already shipped. This IMPL extends
+  its parser shape; the existing public API (`varsfile.Load`)
+  stays stable.
+- **RFC-0003 IMPL (locals + `var.*` namespacing)** — co-ships per
+  DESIGN-0006 OQ-1. Sequencing question is OQ-1 below.
+
+## Open Questions
+
+All six open questions have been resolved. Recorded below for
+audit / traceability; the implementation should follow the
+**Decision** lines.
+
+---
+
+**OQ-1: Sequencing with RFC-0003's IMPL.** DESIGN-0006 OQ-1 fixed
+v0.7.0 as the joint release. The IMPL question is whether this IMPL
+starts before, in parallel with, or after RFC-0003's IMPL. Phase F
+(template strict-vars) touches the `var.*` namespace that RFC-0003
+introduces, so the two must coordinate there.
+
+- **a (recommended):** Start this IMPL's Phases A–B independently
+  (they have zero overlap with RFC-0003); pause before Phase C and
+  wait for RFC-0003's IMPL to land Phases 1–2 (the `var.*` scope
+  builder); resume Phases C–G against that scope. Single resumable
+  branch; no parallel review burden.
+- **b:** Sequence strictly — finish RFC-0003's IMPL completely,
+  then start this one. Simpler review story; biggest calendar
+  delay.
+- **c:** Run both in true parallel on separate branches; merge in
+  the same release. Most coordination overhead; review burden
+  spikes at integration time.
+
+**Decision: a.** Phases A–B land independently; pause before Phase
+C until RFC-0003's IMPL has the `var.*` scope builder available;
+resume on a single branch.
+
+---
+
+**OQ-2: File organization for the validation-block evaluator.**
+Phase C's validation evaluation needs a home.
+
+- **a (recommended):** New file `internal/config/validation.go`
+  housing the `Validation` struct, the load-time schema, and the
+  evaluator (`EvaluateValidations(vars []Variable, scope cty.Value) []error`).
+  Mirrors how `vartype.go` cleanly contains type-expression logic
+  and keeps the schema-evaluator-test trio together.
+- **b:** Inline the evaluator into `internal/create/create.go`
+  alongside the existing variable resolution. Less file
+  proliferation; `create.go` grows further.
+- **c:** Single file `internal/config/vartype.go` from Phase A
+  expands to cover both. Smallest file footprint; conflates two
+  concerns.
+
+**Decision: a.** `internal/config/validation.go` is the home for
+the `Validation` struct, schema, and `EvaluateValidations`. Sibling
+to `internal/config/vartype.go`.
+
+---
+
+**OQ-3: Deprecation warning surfacing channel.** Phase A.4 detects
+the `int` deprecation; Phase B.6 plumbs it to callers. The
+question is what channel to surface it on.
+
+- **a (recommended):** `ui.Warningf` (the existing styled-stderr
+  channel used by IMPL-0008 for unknown vars-file keys). Same
+  warning style users already know; respects `NO_COLOR`.
+- **b:** Structured `slog.Warn` with attrs. Cleaner for
+  machine-parseable logs; less discoverable for interactive users.
+- **c:** Both — emit through `ui.Warningf` for humans *and*
+  `slog.Warn` for log capture. Belt and suspenders; small extra
+  surface.
+
+**Decision: a.** `ui.Warningf` only. Matches IMPL-0008's pattern;
+single source of warning truth.
+
+---
+
+**OQ-4: Migration error format when rejecting legacy `choices` /
+`validate` fields.** Phase B.4 rejects these at load time. The
+question is how heavy the error message should be.
+
+- **a (recommended):** Static error referencing the MIGRATION.md
+  section anchor and showing the *generic* before/after pattern
+  (no auto-suggested fix for the specific variable). Predictable,
+  cheap, matches the v0.5/v0.6 rejection error style.
+- **b:** Smart error that includes the auto-suggested fix for the
+  specific variable, e.g. "variable `license` uses removed
+  `choices = ["MIT", "Apache-2.0"]`; replace with:
+  `validation { condition = contains([\"MIT\", \"Apache-2.0\"], var.license) error_message = \"...\" }`".
+  More helpful but adds formatting complexity and an edge case
+  per legacy field type.
+- **c:** No prose in the error — just the MIGRATION.md anchor URL.
+  Most terse; least informative.
+
+**Decision: a.** Static error w/ generic before/after pattern plus
+the MIGRATION.md anchor. Matches v0.5 / v0.6 rejection style.
+
+---
+
+**OQ-5: Test corpus strategy.** Phase G calls for a forge-registry
+end-to-end smoke test. The question is whether to anchor coverage
+on that single big test or on broad unit/integration coverage
+inside the forge repo.
+
+- **a (recommended):** Broad unit + integration coverage inside
+  the forge repo using fixture blueprints (matches IMPL-0008's
+  approach); treat the forge-registry smoke test as a manual
+  post-merge validation step rather than a CI gate. Keeps CI
+  fast; doesn't couple this repo's CI to a downstream repo.
+- **b:** Add a CI job that clones forge-registry, scaffolds the
+  renovate-config blueprint, and asserts against fixture output.
+  Stronger guarantee; cross-repo CI coupling, slower CI.
+- **c:** Skip forge-registry validation entirely until the
+  follow-up issue (G.5) lands. Lightest weight; biggest
+  integration risk at release time.
+
+**Decision: a.** Broad in-repo unit + integration coverage;
+forge-registry validation is a manual post-merge step (G.5
+follow-up).
+
+---
+
+**OQ-6: `forge info` JSON output for structured types.** The
+existing `forge info --output json` serializes the blueprint
+schema, including variables. With `cty.Type` values in the
+variable surface, the JSON shape needs a decision.
+
+- **a (recommended):** Emit the cty type as its canonical string
+  form (`"list(string)"`, `"object({port: number})"`) — the same
+  text an author would write in `blueprint.hcl`. Stable, human-
+  readable, round-trippable via `typeexpr` if a consumer wants
+  to parse it back.
+- **b:** Emit the cty type as a nested JSON object using cty's
+  built-in JSON marshaling. Machine-friendly; verbose; couples
+  JSON consumers to cty's internal representation.
+- **c:** Emit both — the canonical string form *and* a structured
+  object — under separate keys. Most flexibility; biggest payload.
+
+**Decision: a.** Canonical string form
+(`"list(string)"`, `"object({port: number})"`) under the existing
+`type` key in the JSON output. Round-trippable via `typeexpr`.
+
+---
+
+## References
+
+- [DESIGN-0006 — Object and collection variable types](../design/0006-object-and-collection-variable-types.md) — the design this IMPL realises.
+- [RFC-0002 — Object and collection variable types](../rfc/0002-object-and-collection-variable-types.md) — the upstream proposal.
+- [RFC-0003 — Locals for derived values](../rfc/0003-locals-for-derived-values.md) — co-shipping in v0.7.0 per DESIGN-0006 OQ-1.
+- [DESIGN-0001 — Blueprint Authoring](../design/0001-blueprint-authoring.md) — variable declaration contract this IMPL extends.
+- [DESIGN-0005 — Variable input via vars file](../design/0005-variable-input-via-vars-file.md) — vars-file input mechanism this IMPL extends to structured types.
+- [IMPL-0006 — Migrate lockfile from YAML to HCL](0006-migrate-lockfile-from-yaml-to-hcl.md) — lockfile prerequisite (shipped).
+- [IMPL-0008 — Variable input via vars file](0008-variable-input-via-vars-file.md) — direct precedent for file organisation, test corpus shape, deprecation-warning channel, and docz-reviewer workflow.
+- [ADR-0002 — Forge does not ship in-tool migrators](../adr/0002-forge-does-not-ship-in-tool-migrators.md) — governs the legacy-field-rejection strategy.
+- [`hashicorp/hcl/v2/ext/typeexpr`](https://pkg.go.dev/github.com/hashicorp/hcl/v2/ext/typeexpr) — the type expression parser this IMPL delegates to (DESIGN-0006 OQ-2).
+- `internal/config/blueprint.go` — Variable struct refactor target.
+- `internal/config/hcldec_spec.go` — schema refactor target.
+- `internal/config/validate.go` — `validVariableTypes` removal target.
+- `internal/prompt/prompt.go` — object-unfold + list/map error target.
+- `internal/varsfile/varsfile.go` — coercion-path simplification target.
+- `internal/lockfile/cty.go` — coercion-path simplification target.
+- `internal/template/renderer.go` — strict-vars update target.

--- a/docs/impl/README.md
+++ b/docs/impl/README.md
@@ -40,4 +40,5 @@ docz create impl "Your Implementation Title"
 | IMPL-0006 | Migrate lockfile from YAML to HCL | Draft | 2026-05-18 | Donald Gifford | [0006-migrate-lockfile-from-yaml-to-hcl.md](0006-migrate-lockfile-from-yaml-to-hcl.md) |
 | IMPL-0007 | Remove forge migrate command | Implemented | 2026-05-18 | Donald Gifford | [0007-remove-forge-migrate-command.md](0007-remove-forge-migrate-command.md) |
 | IMPL-0008 | Variable input via vars file | Accepted | 2026-05-19 | Donald Gifford | [0008-variable-input-via-vars-file.md](0008-variable-input-via-vars-file.md) |
+| IMPL-0009 | object and collection variable types | Draft | 2026-06-29 | Donald Gifford | [0009-object-and-collection-variable-types.md](0009-object-and-collection-variable-types.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/rfc/0002-object-and-collection-variable-types.md
+++ b/docs/rfc/0002-object-and-collection-variable-types.md
@@ -13,6 +13,13 @@ created: 2026-05-18
 **Author:** Donald Gifford
 **Date:** 2026-05-18
 
+> **Spun out into [DESIGN-0006 — Object and collection variable
+> types](../design/0006-object-and-collection-variable-types.md)
+> (2026-06-29).** DESIGN-0006 carries the implementation contract,
+> resolved open questions, and migration plan. Treat this RFC as
+> the proposal; treat DESIGN-0006 as the source of truth for
+> what's actually being built.
+
 <!--toc:start-->
 - [Summary](#summary)
 - [Problem Statement](#problem-statement)
@@ -678,11 +685,12 @@ Terraform.
   capabilities (object, list, map) but the OQ-3 decision to drop
   `choice` and the `choices = [...]` / scalar `validate` fields is
   breaking — load-time errors on legacy declarations, no in-tool
-  migrator per ADR-0002. **Decision: minor bump with a documented
-  rescaffold/re-author path.** Probably v0.7.0 alongside RFC-0003,
-  per the sequencing DESIGN-0005 → v0.5.0, IMPL-0006/IMPL-0007 →
-  v0.5.0, RFC-0002/RFC-0003 → v0.7.0; concrete number set when the
-  work lands.
+  migrator per ADR-0002. **Decision: minor bump (v0.7.0) with a
+  documented rescaffold/re-author path; RFC-0002 and RFC-0003 ship
+  together** per DESIGN-0006 OQ-1. Release sequencing:
+  DESIGN-0005 → v0.5.0, IMPL-0006/IMPL-0007 → v0.5.0,
+  IMPL-0008 → v0.6.0, RFC-0002 + RFC-0003 (via DESIGN-0006) →
+  v0.7.0.
 
 - **OQ-5: Do we need a `locals` equivalent?** forge today expresses
   "derived value computed from other variables" by declaring a
@@ -708,6 +716,7 @@ Terraform.
 
 ## References
 
+- [DESIGN-0006 — Object and collection variable types](../design/0006-object-and-collection-variable-types.md) — the design spun out from this RFC; carries the implementation contract and resolved open questions.
 - [ADR-0002 — Forge does not ship in-tool migrators](../adr/0002-forge-does-not-ship-in-tool-migrators.md) — establishes the "no migrator" principle that governs the `choice` removal in this RFC.
 - [DESIGN-0001 — Blueprint Authoring](../design/0001-blueprint-authoring.md) — variable declaration schema this RFC extends.
 - [DESIGN-0005 — Variable input via vars file](../design/0005-variable-input-via-vars-file.md) — input mechanism that unblocks non-scalar values on the CLI side.

--- a/docs/rfc/0003-locals-for-derived-values.md
+++ b/docs/rfc/0003-locals-for-derived-values.md
@@ -567,6 +567,7 @@ explicitly weighed against in-tool tooling and rejected.
 
 - [ADR-0002 — Forge does not ship in-tool migrators](../adr/0002-forge-does-not-ship-in-tool-migrators.md) — drops the originally-planned `forge migrate refs` command; informs the [Migration](#migration) section.
 - [RFC-0002 — Object and collection variable types](0002-object-and-collection-variable-types.md) — the type-system work this RFC composes with; RFC-0002 OQ-5 deferred the locals question here.
+- [DESIGN-0006 — Object and collection variable types](../design/0006-object-and-collection-variable-types.md) — RFC-0002's design; co-ships with this RFC in v0.7.0 per DESIGN-0006 OQ-1.
 - [DESIGN-0001 — Blueprint Authoring](../design/0001-blueprint-authoring.md) — variable declaration schema that gains the `locals` block.
 - [DESIGN-0005 — Variable input via vars file](../design/0005-variable-input-via-vars-file.md) — input-side surface that locals deliberately stay out of.
 - [IMPL-0006 — Migrate lockfile from YAML to HCL](../impl/0006-migrate-lockfile-from-yaml-to-hcl.md) — lockfile format that the locals round-trip depends on.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
         - 'DESIGN-0003: Migrate Template Engine to HCL2': design/0003-migrate-template-engine-to-hcl2.md
         - 'DESIGN-0004: Unify Config File Format After HCL2 Cutover': design/0004-unify-config-file-format-after-hcl2-cutover.md
         - 'DESIGN-0005: Variable input via vars file': design/0005-variable-input-via-vars-file.md
+        - 'DESIGN-0006: object and collection variable types': design/0006-object-and-collection-variable-types.md
     - Implementation Plans:
         - Overview: impl/README.md
         - 'IMPL-0001: Forge Phased Build Plan': impl/0001-forge-phased-build-plan.md
@@ -24,6 +25,7 @@ nav:
         - 'IMPL-0006: Migrate lockfile from YAML to HCL': impl/0006-migrate-lockfile-from-yaml-to-hcl.md
         - 'IMPL-0007: Remove forge migrate command': impl/0007-remove-forge-migrate-command.md
         - 'IMPL-0008: Variable input via vars file': impl/0008-variable-input-via-vars-file.md
+        - 'IMPL-0009: object and collection variable types': impl/0009-object-and-collection-variable-types.md
     - Investigations:
         - Overview: investigation/README.md
         - 'INV-0001: Templating YAML Files and HCL2 Migration': investigation/0001-templating-yaml-files-and-hcl2-migration.md


### PR DESCRIPTION
## Summary

- **DESIGN-0006** (new): adds `object({…})`, `list(T)`, `map(T)` to the variable type surface; replaces `choice` with a Terraform-style `validation { … }` block; deprecates `int` in favour of `number`. Implements [RFC-0002](docs/rfc/0002-object-and-collection-variable-types.md); ships in v0.7.0 alongside RFC-0003 (locals + `var.*` namespace).
- **IMPL-0009** (new): seven-phase implementation plan with checked-off tasks and per-phase success criteria.
- Cross-references updated in RFC-0002, RFC-0003, DESIGN-0005, IMPL-0006, IMPL-0008, ADR-0002 so the new docs are discoverable from the existing trail.

## Decisions baked in

### DESIGN-0006 OQs (all resolved)

| OQ | Topic | Decision |
|---|---|---|
| 1 | RFC-0003 sequencing | Ship both in v0.7.0 simultaneously |
| 2 | Type expression parser | Use `hashicorp/hcl/v2/ext/typeexpr` directly |
| 3 | `error_message` interpolation | Static string only in v1 |
| 4 | Cross-variable validation scope | Allowed; same scope as default eval |
| 5 | Lost `choice` select-list UX | Acknowledged v0.7 regression; follow-up RFC |
| 6 | `int` vs `number` | `int` is an alias for `number`; emit deprecation warning |

### IMPL-0009 OQs (all resolved to `a`)

| OQ | Topic | Decision |
|---|---|---|
| 1 | Sequencing with RFC-0003 IMPL | Land A–B independently, pause before C for `var.*` scope, resume |
| 2 | Validation evaluator file | New `internal/config/validation.go` |
| 3 | Deprecation warning channel | `ui.Warningf` |
| 4 | Legacy-field rejection error format | Static error w/ MIGRATION.md anchor + generic before/after |
| 5 | Test corpus strategy | Broad in-repo unit/integration; forge-registry as manual post-merge |
| 6 | `forge info --output json` shape | Canonical string form (`"list(string)"`, `"object({port: number})"`) |

## Phases (IMPL-0009)

| Phase | What |
|---|---|
| A | Type expression parser (`internal/config/vartype.go`) + `int` deprecation detection |
| B | Variable struct + HCL schema refactor; reject legacy `choices` / `validate` fields |
| C | Default-expression + validation-block evaluation; resolved-variable scope |
| D | Vars-file structured-type support; `--set` object literal parsing; list/map rejection |
| E | Prompt UX (object unfold, list/map non-interactive error, declaration-order preservation) |
| F | Lockfile cty extensions + HCL round-trip; template strict-vars for nested access |
| G | Docs (MIGRATION, REFERENCE, CLAUDE, release notes); forge-registry follow-up; docz review |

## Test plan

- [x] All cross-references resolve (verified by reading)
- [x] `docz update` regenerated the indexes cleanly
- [ ] mkdocs build (will run when this hits CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)