### PR TITLE
fix(prompt): keep structural values as cty.Value through variable resolution

### DIFF
--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -43,9 +43,9 @@ type PromptFn func(v *config.Variable, current map[string]any) (string, error)
 // CollectVariables accepts both for flexibility (tests may stub either
 // path) but does not enforce that exclusion itself.
 //
-// IMPL-0009 Phase B: this function still operates on the legacy
-// scalar-only resolution shape. Structured-type (object / list / map)
-// support and validation-block evaluation land in Phases C and E.
+// Resolved values are `any`: scalars unwrap to string/bool/int64/float64,
+// structural types (object / list / map) stay cty.Value on every branch
+// of the chain.
 func CollectVariables(
 	vars []config.Variable,
 	overrides map[string]string,
@@ -113,7 +113,8 @@ func resolveVariable(
 // resolveFromVarsFile converts a cty.Value supplied via --var-file into
 // the `any` form used throughout the variable resolution chain. The
 // value is already coerced to the declared blueprint type by
-// varsfile.Load, so this is a straightforward Go-type unwrap.
+// varsfile.Load, so this is a straightforward Go-type unwrap for
+// scalars; structural types stay cty.Value (see ctyToGo).
 func resolveFromVarsFile(val cty.Value, v *config.Variable) (any, error) {
 	if !val.IsKnown() || val.IsNull() {
 		if v.Required {
@@ -128,9 +129,18 @@ func resolveFromVarsFile(val cty.Value, v *config.Variable) (any, error) {
 
 // ctyToGo converts a cty.Value to the Go `any` shape this package uses
 // for the resolution chain. Mirrors lockfile.FromCtyValues for the
-// primitive cty types; vars files are scalar-only in IMPL-0008 so
-// nested/structural types don't appear here.
+// primitive cty types.
+//
+// Structural values (object / list / map) pass through as cty.Value —
+// the same shape `--set` object overrides and structured defaults use,
+// and what lockfile.convertValue and the HCL renderer expect. Flattening
+// them to GoString() here produced a Go debug literal that later failed
+// re-conversion with `object required, but have string`.
 func ctyToGo(val cty.Value) any {
+	if !val.Type().IsPrimitiveType() {
+		return val
+	}
+
 	switch val.Type() {
 	case cty.String:
 		return val.AsString()
@@ -581,6 +591,11 @@ func bareValuesToCty(current map[string]any) map[string]cty.Value {
 
 func goToCty(v any) cty.Value {
 	switch x := v.(type) {
+	case cty.Value:
+		// Structural values (and any already-cty scalar) resolved
+		// earlier in the chain. Passing through keeps them traversable,
+		// so a later variable's default can reference `git_provider.org`.
+		return x
 	case string:
 		return cty.StringVal(x)
 	case bool:

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -376,3 +376,100 @@ func TestCollectVariables_ZeroValues(t *testing.T) {
 	assert.Equal(t, false, result["flag"])
 	assert.Equal(t, 0, result["count"])
 }
+
+// TestCollectVariables_VarsFileObject is the regression guard for #42:
+// an object supplied through --var-file must survive the resolution
+// chain as a cty.Value. It used to come back as a GoString() debug
+// literal, which lockfile.ToCtyValues then rejected with
+// `object required, but have string`.
+func TestCollectVariables_VarsFileObject(t *testing.T) {
+	t.Parallel()
+
+	objType := cty.Object(map[string]cty.Type{
+		"name": cty.String,
+		"org":  cty.String,
+		"host": cty.String,
+	})
+
+	vars := []config.Variable{
+		{Name: "git_provider", Type: objType},
+	}
+
+	varsFile := map[string]cty.Value{
+		"git_provider": cty.ObjectVal(map[string]cty.Value{
+			"name": cty.StringVal("forgejo"),
+			"org":  cty.StringVal("homelab"),
+			"host": cty.StringVal("git.fartlab.dev"),
+		}),
+	}
+
+	result, err := prompt.CollectVariables(vars, nil, varsFile, false, nil)
+	require.NoError(t, err)
+
+	got, ok := result["git_provider"].(cty.Value)
+	require.True(t, ok, "object from a vars file must stay a cty.Value")
+	assert.Equal(t, cty.StringVal("forgejo"), got.GetAttr("name"))
+	assert.Equal(t, cty.StringVal("homelab"), got.GetAttr("org"))
+	assert.Equal(t, cty.StringVal("git.fartlab.dev"), got.GetAttr("host"))
+}
+
+// TestCollectVariables_VarsFileCollections covers the list and map
+// arms of the same #42 stringification bug.
+func TestCollectVariables_VarsFileCollections(t *testing.T) {
+	t.Parallel()
+
+	vars := []config.Variable{
+		{Name: "topics", Type: cty.List(cty.String)},
+		{Name: "labels", Type: cty.Map(cty.String)},
+	}
+
+	varsFile := map[string]cty.Value{
+		"topics": cty.ListVal([]cty.Value{cty.StringVal("go"), cty.StringVal("k8s")}),
+		"labels": cty.MapVal(map[string]cty.Value{"tier": cty.StringVal("backend")}),
+	}
+
+	result, err := prompt.CollectVariables(vars, nil, varsFile, false, nil)
+	require.NoError(t, err)
+
+	topics, ok := result["topics"].(cty.Value)
+	require.True(t, ok, "list from a vars file must stay a cty.Value")
+	assert.Equal(t, 2, topics.LengthInt())
+
+	labels, ok := result["labels"].(cty.Value)
+	require.True(t, ok, "map from a vars file must stay a cty.Value")
+	assert.Equal(t, cty.StringVal("backend"), labels.Index(cty.StringVal("tier")))
+}
+
+// TestCollectVariables_ObjectAttrInLaterDefault covers the second half
+// of #42: goToCty stringified an already-resolved cty.Value when
+// building the EvalContext, so a later variable's default could not
+// traverse into an object attribute.
+func TestCollectVariables_ObjectAttrInLaterDefault(t *testing.T) {
+	t.Parallel()
+
+	objType := cty.Object(map[string]cty.Type{
+		"org":  cty.String,
+		"host": cty.String,
+	})
+
+	vars := []config.Variable{
+		{Name: "git_provider", Type: objType},
+		{
+			Name:          "module_path",
+			Type:          cty.String,
+			DefaultSource: "${git_provider.host}/${git_provider.org}/demo",
+		},
+	}
+
+	varsFile := map[string]cty.Value{
+		"git_provider": cty.ObjectVal(map[string]cty.Value{
+			"org":  cty.StringVal("homelab"),
+			"host": cty.StringVal("git.fartlab.dev"),
+		}),
+	}
+
+	result, err := prompt.CollectVariables(vars, nil, varsFile, true, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "git.fartlab.dev/homelab/demo", result["module_path"])
+}


### PR DESCRIPTION
Fixes #42. Unblocks forge-registry IMPL-0003 Phase 7 (the `git_provider`
object consolidation), which is gated on this.

## The bug

`internal/prompt.ctyToGo` switched on `val.Type()` and fell through to
`val.GoString()` — the Go *debug* representation — for anything that
wasn't `cty.String` / `cty.Bool` / `cty.Number`. So an object, list, or
map loaded from a `--var-file` left the resolution chain as a string.
`lockfile.ToCtyValues` then couldn't convert it back:

```console
$ forge create demo/app --var-file forgejo.forge-vars.hcl
Error: converting variables to cty: variable "git_provider": object required, but have string
```

The helper's own comment explains why — *"vars files are scalar-only in
IMPL-0008 so nested/structural types don't appear here"* — an assumption
IMPL-0009 invalidated when it added `object({…})` / `list(T)` / `map(T)`
without revisiting this arm. `docs/REFERENCE.md` already documents
structured values in vars files as supported (v0.7+), so the docs were
right and the code was the outlier.

The var-file loader itself is fine: it type-checks the object against the
declared shape and rejects partials with a good message. Only the
handoff into the resolution map was lossy.

### Second, related arm

`goToCty` had the mirror-image bug. It projects the in-flight `any` map
into an `hcl.EvalContext`, and stringified an already-resolved
`cty.Value` via its `default:` case. A later variable whose default
traverses an object attribute therefore failed:

```
rendering default for "module_path": Unsupported attribute;
Can't access attributes on a primitive-typed value (string).
```

That one affected the `--set` object-literal path too, not just vars
files, since `parseObjectOverride` also returns a `cty.Value`.

## The fix

Both helpers now pass structural values through unchanged, matching
`lockfile.convertValue`, which already short-circuits on a `cty.Value`
input. Two guards, no behavior change for scalars.

## Verification

Three regression tests added; all three fail on `main` and pass here
(confirmed by stashing the `prompt.go` change and re-running).

End-to-end against a scratch registry with an `object({name, org, host,
renovate_config_prefix})` variable supplied by var-file:

| | stock `806263d` | this branch |
|---|---|---|
| object via `--var-file` | `object required, but have string` | scaffolds |
| attribute in template | — | `module git.fartlab.dev/homelab/objtest` |
| `condition { when = git_provider.name != "github" }` | — | routes correctly (`.forgejo/` shipped, `.github/` excluded) |
| bad `git_provider.name` via var-file | — | `git_provider.name must be one of: forgejo, github.` with position |

No regression: all 19 forge-registry blueprints scaffold green on a
build of this branch (`scripts/scaffold-smoke.sh` → 19 passed, 0 failed).

Full `go test ./...` passes. `golangci-lint` could not run in this
environment (the installed binary is built with go1.25, repo targets
1.26.2) — pre-existing, unrelated to this change; `go vet` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)